### PR TITLE
refactor : 서버 에러코드 대응 & NetworkError재정의 & validateResponse부분 수정

### DIFF
--- a/Projects/Core/Network/Interface/Sources/Error/FeelinAPIError.swift
+++ b/Projects/Core/Network/Interface/Sources/Error/FeelinAPIError.swift
@@ -1,0 +1,82 @@
+//
+//  FeelinAPIError.swift
+//  CoreNetworkInterface
+//
+//  Created by 황인우 on 7/6/24.
+//
+
+import Foundation
+
+public enum FeelinAPIError: LocalizedError, Equatable {
+    case invalidRequest(errorMessage: String)
+    case invalidRequestInput(errorMessage: String)
+    case unexpectedServerError(errorMessage: String)
+    case refreshTokenNotFound(errorMessage: String)
+    case tokenIsExpired(errorMessage: String)
+    case wrongTokenTypePassed(errorMessage: String)
+    case unsupportedAuthProvider(errorMessage: String)
+    case invalidToken(errorMessage: String)
+    case invalidPublicKey(errorMessage: String)
+    case invalidSecretKey(errorMessage: String)
+    case userDataNotFound(errorMessage: String)
+    case artistDataNotFound(errorMessage: String)
+    case dataFailedValidation(errorMessage: String)
+    case recordDataNotFound(errorMessage: String)
+    case unknown(errorCode: String, errorMessage: String)
+    
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRequest(let errorMessage),
+             .invalidRequestInput(let errorMessage),
+             .unexpectedServerError(let errorMessage),
+             .refreshTokenNotFound(let errorMessage),
+             .tokenIsExpired(let errorMessage),
+             .wrongTokenTypePassed(let errorMessage),
+             .unsupportedAuthProvider(let errorMessage),
+             .invalidToken(let errorMessage),
+             .invalidPublicKey(let errorMessage),
+             .invalidSecretKey(let errorMessage),
+             .userDataNotFound(let errorMessage),
+             .artistDataNotFound(let errorMessage),
+             .dataFailedValidation(let errorMessage),
+             .recordDataNotFound(let errorMessage),
+             .unknown(_, let errorMessage):
+            return errorMessage
+        }
+    }
+    
+    public init(apiFailResponse: APIFailResponse) {
+        switch apiFailResponse.errorCode {
+        case "00000":
+            self = .invalidRequest(errorMessage: apiFailResponse.errorMessage)
+        case "00001":
+            self = .invalidRequestInput(errorMessage: apiFailResponse.errorMessage)
+        case "00002":
+            self = .unexpectedServerError(errorMessage: apiFailResponse.errorMessage)
+        case "01000":
+            self = .refreshTokenNotFound(errorMessage: apiFailResponse.errorMessage)
+        case "01001":
+            self = .tokenIsExpired(errorMessage: apiFailResponse.errorMessage)
+        case "01002":
+            self = .wrongTokenTypePassed(errorMessage: apiFailResponse.errorMessage)
+        case "01003":
+            self = .unsupportedAuthProvider(errorMessage: apiFailResponse.errorMessage)
+        case "01004":
+            self = .invalidToken(errorMessage: apiFailResponse.errorMessage)
+        case "01005":
+            self = .invalidPublicKey(errorMessage: apiFailResponse.errorMessage)
+        case "01006":
+            self = .invalidSecretKey(errorMessage: apiFailResponse.errorMessage)
+        case "02000":
+            self = .userDataNotFound(errorMessage: apiFailResponse.errorMessage)
+        case "03000":
+            self = .artistDataNotFound(errorMessage: apiFailResponse.errorMessage)
+        case "03001":
+            self = .dataFailedValidation(errorMessage: apiFailResponse.errorMessage)
+        case "04000":
+            self = .recordDataNotFound(errorMessage: apiFailResponse.errorMessage)
+        default:
+            self = .unknown(errorCode: apiFailResponse.errorCode, errorMessage: apiFailResponse.errorMessage)
+        }
+    }
+}

--- a/Projects/Core/Network/Interface/Sources/Error/NetworkError.swift
+++ b/Projects/Core/Network/Interface/Sources/Error/NetworkError.swift
@@ -14,7 +14,7 @@ public enum NetworkError: Error, Equatable {
     case serverError(ServerError)
     case noResponseError
     case decodingError( _ description: String)
-    case customServerError(APIFailResponse)
+    case feelinAPIError(FeelinAPIError)
     case requestInterceptError(_ description: String)
     case unknownError( _ description: String)
 
@@ -26,7 +26,7 @@ public enum NetworkError: Error, Equatable {
         case let .serverError(serverError):             return serverError.errorMessage
         case .noResponseError:                          return "No Response"
         case .decodingError:                            return "Decoding Error"
-        case let .customServerError(apiFailResponse):   return apiFailResponse.errorMessage
+        case let .feelinAPIError(feelinAPiError):       return feelinAPiError.localizedDescription
         case let .requestInterceptError(description):   return "RequestInterceptError: \(description)"
         case .unknownError:                             return "Unknown Error"
         }

--- a/Projects/Core/Network/Sources/NetworkProvider.swift
+++ b/Projects/Core/Network/Sources/NetworkProvider.swift
@@ -25,8 +25,7 @@ public final class NetworkProvider: NetworkProviderInterface {
 
             return networkSession
                 .dataTaskPublisher(for: urlRequest)
-                .tryDecodeAPIFailResponse()
-                .validateStatusCode()
+                .validateResponse()
                 .retryOnUnauthorized(
                     session: networkSession,
                     request: urlRequest


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [ ] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경
http statusCode로 설명할 수 없는 오류들을 처리해야 하기에 서버쪽에서 에러 발생시 추가적으로 에러코드를 클라이언트로 보내기로 합의가 되었습니다.
해당 errorcode에 대응하여 기존에 구현되어있던 `NetworkError`를 수정해야 합니다.

## 목표
 - ErrorCode 정의
 - NetworkError 리팩토링

## 결과 (Optional)
2024년 7월 6일까지 추가된 에러코드에 대응하여 클라이언트쪽에서 에러처리를 할 수 있습니다.