### PR TITLE
Refactor/ FlexLayout의 dependency 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,9 @@ master.key
 ### xcconfig ###
 Projects/App/xcconfigs/KakaoSecretKeys.xcconfig
 Projects/App/xcconfigs/TokenKeys.xcconfig
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+Carthage/Checkouts/
+Carthage/Build/

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "layoutBox/FlexLayout"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "layoutBox/FlexLayout" "2.0.10"

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -23,8 +23,7 @@ let appTargets: [Target] = [
             infoPlist: Project.Environment.appInfoPlist(deploymentTarget: .dev), 
             entitlements: "Feelin.entitlements",
             dependencies: [
-                .coordinator,
-                .SPM.FlexLayout
+                .coordinator
             ],
             settings: Project.Environment.devTargetSettings
         )
@@ -36,8 +35,7 @@ let appTargets: [Target] = [
             infoPlist: Project.Environment.appInfoPlist(deploymentTarget: .qa),
             entitlements: "Feelin.entitlements",
             dependencies: [
-                .coordinator,
-                .SPM.FlexLayout
+                .coordinator
             ],
             settings: Project.Environment.qaTargetSettings
         )
@@ -49,8 +47,7 @@ let appTargets: [Target] = [
             infoPlist: Project.Environment.appInfoPlist(deploymentTarget: .prod),
             entitlements: "Feelin.entitlements",
             dependencies: [
-                .coordinator,
-                .SPM.FlexLayout
+                .coordinator
             ],
             settings: Project.Environment.prodTargetSettings
         )
@@ -59,9 +56,6 @@ let appTargets: [Target] = [
 
 let appProject: Project = .makeModule(
     name: Project.Environment.appName,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: appTargets,
     schemes: appSchemes,
     additionalFiles: [

--- a/Projects/Coordinator/App/Project.swift
+++ b/Projects/Coordinator/App/Project.swift
@@ -12,11 +12,7 @@ import DependencyPlugin
 let targets: [Target] = [
     .coordinator(
         interface: .App,
-        factory: .init(
-            dependencies: [
-                .SPM.FlexLayout
-            ]
-        )
+        factory: .init()
     ),
     .coordinator(
         implements: .App,
@@ -46,8 +42,5 @@ let targets: [Target] = [
 
 let project = Project.makeModule(
     name: ModulePath.Coordinator.name + ModulePath.Coordinator.App.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: targets
 )

--- a/Projects/Coordinator/Main/Project.swift
+++ b/Projects/Coordinator/Main/Project.swift
@@ -4,17 +4,13 @@ import DependencyPlugin
 
 let project = Project.makeModule(
     name: ModulePath.Coordinator.name + ModulePath.Coordinator.Main.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: [
         .coordinator(
             interface: .Main,
             factory: .init(
                 dependencies: [
                     .feature,
-                    .coordinator(interface: .App),
-                    .SPM.FlexLayout
+                    .coordinator(interface: .App)
                 ]
             )
         ),

--- a/Projects/Coordinator/Onboarding/Project.swift
+++ b/Projects/Coordinator/Onboarding/Project.swift
@@ -4,9 +4,6 @@ import DependencyPlugin
 
 let project = Project.makeModule(
     name: ModulePath.Coordinator.name + ModulePath.Coordinator.Onboarding.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: [
         .coordinator(
             interface: .Onboarding,
@@ -16,7 +13,6 @@ let project = Project.makeModule(
                     .coordinator(interface: .Main),
                     .coordinator(interface: .App),
                     .coordinator(interface: .TabBar),
-                    .SPM.FlexLayout
                 ]
             )
         ),

--- a/Projects/Coordinator/Project.swift
+++ b/Projects/Coordinator/Project.swift
@@ -16,8 +16,7 @@ let targets: [Target] = [
                 .coordinator(implements: .App),
                 .coordinator(implements: .TabBar),
                 .coordinator(implements: .Onboarding),
-                .coordinator(implements: .Main),
-                .SPM.FlexLayout
+                .coordinator(implements: .Main)
             ]
         )
     )
@@ -25,8 +24,5 @@ let targets: [Target] = [
 
 let project: Project = .makeModule(
     name: "Coordinator",
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: targets
 )

--- a/Projects/Coordinator/TabBar/Project.swift
+++ b/Projects/Coordinator/TabBar/Project.swift
@@ -4,9 +4,6 @@ import DependencyPlugin
 
 let project = Project.makeModule(
     name: ModulePath.Coordinator.name + ModulePath.Coordinator.TabBar.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: [
         .coordinator(
             interface: .TabBar,
@@ -14,7 +11,6 @@ let project = Project.makeModule(
                 dependencies: [
                     .coordinator(interface: .App),
                     .coordinator(interface: .Main),
-                    .SPM.FlexLayout
                 ]
             )
         ),

--- a/Projects/Feature/Main/Project.swift
+++ b/Projects/Feature/Main/Project.swift
@@ -8,7 +8,6 @@ let targets: [Target] = [
         factory: .init(
             dependencies: [
                 .dependencyInjection,
-                .SPM.FlexLayout,
                 .shared
             ]
         )
@@ -46,8 +45,7 @@ let targets: [Target] = [
                 .feature(implements: .Main),
                 .feature(interface: .Main),
                 .feature(testing: .Main),
-                .dependencyInjection,
-                .SPM.FlexLayout
+                .dependencyInjection
             ],
             settings: Project.Environment.exampleAppDefaultSettings
         )
@@ -56,8 +54,5 @@ let targets: [Target] = [
 
 let project = Project.makeModule(
     name: ModulePath.Feature.name + ModulePath.Feature.Main.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: targets
 )

--- a/Projects/Feature/Onboarding/Project.swift
+++ b/Projects/Feature/Onboarding/Project.swift
@@ -14,8 +14,7 @@ let targets: [Target] = [
         interface: .Onboarding,
         factory: .init(
             dependencies: [
-                .dependencyInjection,
-                .SPM.FlexLayout
+                .dependencyInjection
             ]
         )
     ),
@@ -50,7 +49,6 @@ let targets: [Target] = [
             dependencies: [
                 .feature(implements: .Onboarding),
                 .feature(interface: .Onboarding),
-                .SPM.FlexLayout
             ],
             settings: Project.Environment.exampleAppDefaultSettings
         )

--- a/Projects/Feature/Project.swift
+++ b/Projects/Feature/Project.swift
@@ -15,8 +15,7 @@ let targets: [Target] = [
             dependencies: [
                 .feature(implements: .Onboarding),
                 .feature(implements: .Main),
-                .dependencyInjection,
-                .SPM.FlexLayout
+                .dependencyInjection
             ]
         )
     )

--- a/Projects/Shared/DesignSystem/Project.swift
+++ b/Projects/Shared/DesignSystem/Project.swift
@@ -14,8 +14,7 @@ let targets: [Target] = [
         implements: .DesignSystem,
         factory: .init(
             dependencies: [
-                .shared(implements: .ThirdPartyLib),
-                .SPM.FlexLayout
+                .shared(implements: .ThirdPartyLib)
             ]
         )
     )
@@ -23,9 +22,6 @@ let targets: [Target] = [
 
 let project: Project = .makeModule(
     name: ModulePath.Shared.DesignSystem.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: targets,
     resourceSynthesizers: [
         .assets(),

--- a/Projects/Shared/Project.swift
+++ b/Projects/Shared/Project.swift
@@ -15,7 +15,7 @@ let targets: [Target] = [
             dependencies: [
                 .shared(implements: .Util),
                 .shared(implements: .DesignSystem),
-                .SPM.FlexLayout
+                .shared(implements: .ThirdPartyLib)
             ]
         )
     )
@@ -23,8 +23,5 @@ let targets: [Target] = [
 
 let project: Project = .makeModule(
     name: ModulePath.Shared.name,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: targets
 )

--- a/Projects/Shared/ThirdPartyLib/Project.swift
+++ b/Projects/Shared/ThirdPartyLib/Project.swift
@@ -25,7 +25,8 @@ let targets: [Target] = [
                 .SPM.PinLayout,
                 .SPM.KakaoSDKAuth,
                 .SPM.KakaoSDKUser,
-                .SPM.KakaoSDKCommon
+                .SPM.KakaoSDKCommon,
+                .Carthage.FlexLayout
             ]
         )
     )

--- a/Projects/Shared/Util/Project.swift
+++ b/Projects/Shared/Util/Project.swift
@@ -19,8 +19,7 @@ let targets: [Target] = [
                     type: .framework,
                     status: .optional,
                     condition: nil
-                ),
-                .SPM.FlexLayout
+                )
             ]
         )
     )
@@ -28,8 +27,5 @@ let targets: [Target] = [
 
 let project = Project.makeModule(
     name: ModulePath.Shared.Util.rawValue,
-    packages: [
-        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
-    ],
     targets: targets
 )

--- a/Tuist/ProjectDescriptionHelpers/SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/SPM.swift
@@ -9,11 +9,11 @@ import ProjectDescription
 
 extension TargetDependency {
     public struct SPM {}
+    public struct Carthage{}
 }
 
 public extension TargetDependency.SPM {
     static let Kingfisher = Self.package(product: "Kingfisher")
-    static let FlexLayout = Self.package(product: "FlexLayout")
     static let PinLayout = Self.package(product: "PinLayout")
     static let KakaoSDKCommon = Self.package(product: "KakaoSDKCommon")
     static let KakaoSDKAuth = Self.package(product: "KakaoSDKAuth")
@@ -25,5 +25,25 @@ public extension TargetDependency.SPM {
 
     private static func package(product: String) -> TargetDependency {
         return TargetDependency.package(product: product)
+    }
+}
+
+public extension TargetDependency.Carthage {
+    static let FlexLayout = Self.xcframework(
+        path: .relativeToRoot("Carthage/Build/FlexLayout.xcframework"),
+        status: .optional,
+        condition: nil
+    )
+    
+    private static func xcframework(
+        path: ProjectDescription.Path,
+        status: ProjectDescription.FrameworkStatus,
+        condition: ProjectDescription.PlatformCondition?
+    ) -> TargetDependency {
+        return TargetDependency.xcframework(
+            path: path,
+            status: status,
+            condition: condition
+        )
     }
 }


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [x] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경


### 문제점:
#### 1. SPM을 활용하여 FlexLayout을 활용하니 다양한 의존 관계 속에서 Domain, Core 모듈에서 Flex Yoga 관련 오류 발생
```
 FlexLayout - YGEnums.h' file not found
```
#### 2. FlexLayout을 사용해야 하는 모듈에는 다음과 같이 dependency를 상시 추가하여야만 build가 정상적으로 되는 불편함

``` swift
import ProjectDescription
import ProjectDescriptionHelpers
import DependencyPlugin

let project = Project.makeModule(
    name: ModulePath.Coordinator.name + ModulePath.Coordinator.Main.rawValue,
    packages: [
        .remote(url: "https://github.com/layoutBox/FlexLayout", requirement: .upToNextMajor(from: "2.0.7"))
    ],
    targets: [
        .coordinator(
            interface: .Main,
            factory: .init(
                dependencies: [
                    .feature,
                    .coordinator(interface: .App),
                    .SPM.FlexLayout
                ]
            )
        ),
        .coordinator(
            implements: .Main,
            factory: .init(
                dependencies: [
                    .coordinator(interface: .Main)
                ]
            )
        ),
        .coordinator(
            testing: .Main,
            factory: .init(
                dependencies: [
                    .coordinator(interface: .Main)
                ]
            )
        ),
        .coordinator(
            tests: .Main,
            factory: .init(
                dependencies: [
                    .coordinator(testing: .Main)
                ]
            )
        )
    ]
)

```

**FlexLayout 때문에 의존성이 복잡하게 얽혀서 잦은 빌드 오류가 발생하며 해당 문제를 해결해야 합니다.**

## 목표
- FlexLayout의 의존성 간소화
  - Shared 모듈에 해당 소스를 추가하면 다른 모듈에는 위와 같은 dependency에 flexlayout을 추가하지 않고 shared 모듈만 import하면 활용할 수 있도록 수정

## 결과 (Optional)
Carthage를 활용하여 FlexLayout을 xcframework로 만들어서 활용하는 방법으로 위 언급한 의존성 문제 해결

## 이전 프로젝트의 의존성 그래프:
![flexDependencyBefore](https://github.com/user-attachments/assets/55411031-9cf2-4d95-98b9-9a3337eb4fd0)

## FlexLayout을 xcframework로 전환한 뒤 프로젝트의 의존성 그래프:
![flexDependencyAfter](https://github.com/user-attachments/assets/2bce8478-d0b2-41fa-a59d-b09b6303c854)

FlexLayout을 SPM을 통해 불러와 사용할 때에는 UI와 관련된 모든 프레임워크들이 FlexLayout을 직접적으로 의존해야 하여 그래프가 매우 복잡하였다.

FlexLayout을 xcframework로 만들어서 활용하니 복잡한 의존성 문제가 해결이 되었으며 Shared 모듈에 의존하는 모든 feature들이 에러 없이 FlexLayout을 사용할 수 있게 되었다. 또한 Domain 및 Core 모듈에서 관련 에러들이 발생하지 않아 정상적으로 빌드 되는 것을 확인하였습니다.

## 추신

@derrickkim0109 
Carthage를 활용하여 flexlayout을 xcframework로 만들어서 사용하였습니다.
`tuist generate` 하시기 전에

` carthage update --use-xcframeworks --platform iOS` 명령어를 먼저 입력하여 필요한 소스코드를 받아온 뒤 `tuist generate` 하시면 되겠습니다.

만약 carthage가 깔려있지 않으시다면 `brew install carthage`로 먼저 carthage를 설치하세요~
