### PR TITLE
Feat/Scrum 182 커뮤니티 화면 UI 및 로직 초기 구현

### DIFF
--- a/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
+++ b/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
@@ -19,6 +19,8 @@ public enum FeelinAPI<R> {
     case getArtists(cursor: Int?, size: Int)
     case searchArtists(query: String, cursor: Int?, size: Int)
     case postFavoriteArtists(ids: [Int])
+    case postFavoriteArtist(id: Int)
+    case deleteFavoriteArtist(id: Int)
     case getFavoriteArtists(cursor: Int?, size: Int)
     case getFavoriteArtistsRelatedNotes(cursor: Int?, size: Int, hasLyrics: Bool)
     case postLikes(noteID: Int)
@@ -30,6 +32,7 @@ public enum FeelinAPI<R> {
     case searchSongs(cursor: Int, size: Int, query: String, artistID: Int)
     case getSearchedNotes(pageNumber: Int, pageSize: Int, query: String)
     case getSongNotes(cursor: Int?, size: Int, hasLyrics: Bool, songID: Int)
+    case getArtistNotes(cursor: Int?, size: Int, hasLyrics: Bool, artistID: Int)
     case getNoteWithComments(noteID: Int)
     case postComment(body: PostCommentRequest)
     case deleteComment(commentID: Int)
@@ -139,6 +142,27 @@ extension FeelinAPI: HTTPNetworking {
                 "songId": "\(songID)"
             ]
             
+        case .getArtistNotes(let cursor, let size, let hasLyrics, let artistID):
+            if let cursor = cursor {
+                return [
+                    "cursor": "\(cursor)",
+                    "size": "\(size)",
+                    "hasLyrics": "\(hasLyrics)",
+                    "artistId": "\(artistID)"
+                ]
+            }
+            
+            return [
+                "size": "\(size)",
+                "hasLyrics": "\(hasLyrics)",
+                "artistId": "\(artistID)"
+            ]
+        case .postFavoriteArtist(let id),
+             .deleteFavoriteArtist(let id):
+            return [
+                "artistId": id
+            ]
+            
         default:
             return nil
         }
@@ -209,7 +233,9 @@ extension FeelinAPI: HTTPNetworking {
         case .postFavoriteArtists:
             return "/api/v1/favorite-artists/batch"
             
-        case .getFavoriteArtists:
+        case .getFavoriteArtists,
+             .postFavoriteArtist,
+             .deleteFavoriteArtist:
             return "/api/v1/favorite-artists"
             
         case .getFavoriteArtistsRelatedNotes:
@@ -238,6 +264,9 @@ extension FeelinAPI: HTTPNetworking {
         case .getSongNotes:
             return "/api/v1/notes/songs"
             
+        case .getArtistNotes:
+            return "/api/v1/notes/artists"
+            
         case .postComment:
             return "/api/v1/comments"
             
@@ -259,7 +288,8 @@ extension FeelinAPI: HTTPNetworking {
              .postBookmarks,
              .postNote,
              .postComment, 
-             .reportNote:
+             .reportNote,
+             .postFavoriteArtist:
             return .post
 
         case .checkUserValidity, 
@@ -270,13 +300,15 @@ extension FeelinAPI: HTTPNetworking {
              .searchSongs,
              .getSearchedNotes,
              .getSongNotes,
-             .getNoteWithComments:
+             .getNoteWithComments,
+             .getArtistNotes:
             return .get
             
         case .deleteLikes, 
              .deleteBookmarks,
              .deleteNote,
-             .deleteComment:
+             .deleteComment,
+             .deleteFavoriteArtist:
             return .delete
         }
     }

--- a/Projects/Domain/Artist/Interface/Sources/Services/ArtistAPIService.swift
+++ b/Projects/Domain/Artist/Interface/Sources/Services/ArtistAPIService.swift
@@ -22,6 +22,8 @@ public protocol ArtistAPIServiceInterface {
     ) -> AnyPublisher<GetArtistsResponse, ArtistError>
     func postFavoriteArtists(ids: [Int]) -> AnyPublisher<FeelinDefaultResponse, ArtistError>
     func getFavoriteArtists(currentPage: Int?, numberOfArtists: Int) -> AnyPublisher<GetFavoriteArtistsResponse, ArtistError>
+    func postFavoriteArtist(id: Int) -> AnyPublisher<FeelinSuccessResponse, ArtistError>
+    func deleteFavoriteArtist(id: Int) -> AnyPublisher<FeelinSuccessResponse, ArtistError>
 }
 
 public struct ArtistAPIService: ArtistAPIServiceInterface {
@@ -75,6 +77,23 @@ public struct ArtistAPIService: ArtistAPIServiceInterface {
             cursor: currentPage,
             size: numberOfArtists
         )
+        return networkProvider.request(endpoint)
+            .mapError(ArtistError.init)
+            .eraseToAnyPublisher()
+    }
+    
+    public func postFavoriteArtist(id: Int) -> AnyPublisher<FeelinSuccessResponse, ArtistError> {
+        let endpoint = FeelinAPI<FeelinSuccessResponse>.postFavoriteArtist(id: id)
+        
+        return networkProvider.request(endpoint)
+            .mapError(ArtistError.init)
+            .eraseToAnyPublisher()
+        
+    }
+    
+    public func deleteFavoriteArtist(id: Int) -> AnyPublisher<FeelinSuccessResponse, ArtistError> {
+        let endpoint = FeelinAPI<FeelinSuccessResponse>.deleteFavoriteArtist(id: id)
+        
         return networkProvider.request(endpoint)
             .mapError(ArtistError.init)
             .eraseToAnyPublisher()

--- a/Projects/Domain/Artist/Interface/Sources/UseCase/SetFavoriteArtistUseCase.swift
+++ b/Projects/Domain/Artist/Interface/Sources/UseCase/SetFavoriteArtistUseCase.swift
@@ -1,0 +1,41 @@
+//
+//  SetFavoriteArtistUseCase.swift
+//  DomainArtistInterface
+//
+//  Created by 황인우 on 10/3/24.
+//
+
+import Core
+
+import Combine
+import Foundation
+
+public protocol SetFavoriteArtistUseCaseInterface {
+    func execute(
+        artistID: Int,
+        isFavorite: Bool
+    ) -> AnyPublisher<Bool, ArtistError>
+}
+
+public struct SetFavoriteArtistUseCase: SetFavoriteArtistUseCaseInterface {
+    private let artistAPIService: ArtistAPIServiceInterface
+    
+    public init(artistAPIService: ArtistAPIServiceInterface) {
+        self.artistAPIService = artistAPIService
+    }
+    
+    public func execute(
+        artistID: Int,
+        isFavorite: Bool
+    ) -> AnyPublisher<Bool, ArtistError> {
+        if isFavorite {
+            return artistAPIService.postFavoriteArtist(id: artistID)
+                .map(\.success)
+                .eraseToAnyPublisher()
+        } else {
+            return artistAPIService.deleteFavoriteArtist(id: artistID)
+                .map(\.success)
+                .eraseToAnyPublisher()
+        }
+    }
+}

--- a/Projects/Domain/Artist/Sources/MockArtistAPIService.swift
+++ b/Projects/Domain/Artist/Sources/MockArtistAPIService.swift
@@ -57,5 +57,14 @@ public struct MockArtistAPIService: ArtistAPIServiceInterface {
         }
     }
     
+    public func postFavoriteArtist(id: Int) -> AnyPublisher<FeelinSuccessResponse, ArtistError> {
+        return Empty()
+            .eraseToAnyPublisher()
+    }
+    
+    public func deleteFavoriteArtist(id: Int) -> AnyPublisher<FeelinSuccessResponse, DomainArtistInterface.ArtistError> {
+        return Empty()
+            .eraseToAnyPublisher()
+    }
     
 }

--- a/Projects/Domain/Note/Interface/Sources/Services/NoteAPIServiceInterface.swift
+++ b/Projects/Domain/Note/Interface/Sources/Services/NoteAPIServiceInterface.swift
@@ -48,4 +48,11 @@ public protocol NoteAPIServiceInterface {
         hasLyrics: Bool,
         songID: Int
     ) -> AnyPublisher<GetNotesResponse, NoteError>
+    
+    func getArtistNotes(
+        currentPage: Int?,
+        numberOfNotes: Int,
+        hasLyrics: Bool,
+        artistID: Int
+    ) -> AnyPublisher<GetNotesResponse, NoteError>
 }

--- a/Projects/Domain/Note/Interface/Sources/UseCases/GetArtistNotesUseCase.swift
+++ b/Projects/Domain/Note/Interface/Sources/UseCases/GetArtistNotesUseCase.swift
@@ -1,0 +1,83 @@
+//
+//  GetArtistNotesUseCase.swift
+//  DomainNoteInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import Foundation
+import Combine
+
+import Core
+
+public protocol GetArtistNotesUseCaseInterface {
+    func execute(
+        isInitial: Bool,
+        artistID: Int,
+        perPage: Int,
+        mustHaveLyrics: Bool
+    ) -> AnyPublisher<[Note], NoteError>
+}
+
+public struct GetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
+    private let noteAPIService: NoteAPIServiceInterface
+    private let notePaginationService: NotePaginationServiceInterface
+    
+    public init(
+        noteAPIService: NoteAPIServiceInterface,
+        notePaginationService: NotePaginationServiceInterface
+    ) {
+        self.noteAPIService = noteAPIService
+        self.notePaginationService = notePaginationService
+    }
+    
+    public func execute(
+        isInitial: Bool,
+        artistID: Int,
+        perPage: Int,
+        mustHaveLyrics: Bool
+    ) -> AnyPublisher<[Note], NoteError> {
+        if notePaginationService.isLoading {
+            return Empty()
+                .eraseToAnyPublisher()
+        }
+        
+        if isInitial {
+            self.notePaginationService.update(
+                currentPage: nil,
+                hasNextPage: true
+            )
+        }
+        
+        guard notePaginationService.hasNextPage else {
+            return Empty()
+                .eraseToAnyPublisher()
+        }
+        
+        notePaginationService.setLoading(true)
+        
+        return noteAPIService.getArtistNotes(
+            currentPage: notePaginationService.currentPage,
+            numberOfNotes: perPage,
+            hasLyrics: mustHaveLyrics,
+            artistID: artistID
+        )
+        .receive(on: DispatchQueue.main)
+        .map { [weak notePaginationService] notesResponse in
+            notePaginationService?.update(
+                currentPage: notesResponse.nextCursor,
+                hasNextPage: notesResponse.hasNext
+            )
+            notePaginationService?.setLoading(false)
+            
+            return notesResponse.data.map(Note.init)
+        }
+        .catch { [weak notePaginationService] error -> AnyPublisher<[Note], NoteError> in
+            notePaginationService?.setLoading(false)
+            
+            return Fail(error: error)
+                .eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Domain/Note/Sources/NoteAPIService.swift
+++ b/Projects/Domain/Note/Sources/NoteAPIService.swift
@@ -130,4 +130,22 @@ public struct NoteAPIService: NoteAPIServiceInterface {
             .mapError(NoteError.init)
             .eraseToAnyPublisher()
     }
+    
+    public func getArtistNotes(
+        currentPage: Int?,
+        numberOfNotes: Int,
+        hasLyrics: Bool,
+        artistID: Int
+    ) -> AnyPublisher<GetNotesResponse, NoteError> {
+        let endpoint = FeelinAPI<GetNotesResponse>.getArtistNotes(
+            cursor: currentPage,
+            size: numberOfNotes,
+            hasLyrics: hasLyrics,
+            artistID: artistID
+        )
+        
+        return networkProvider.request(endpoint)
+            .mapError(NoteError.init)
+            .eraseToAnyPublisher()
+    }
 }

--- a/Projects/Feature/Main/Interface/Sources/Errors/CommunityError.swift
+++ b/Projects/Feature/Main/Interface/Sources/Errors/CommunityError.swift
@@ -1,0 +1,37 @@
+//
+//  CommunityError.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/3/24.
+//
+
+import Domain
+
+import Foundation
+
+public enum CommunityError: LocalizedError {
+    case noteError(NoteError)
+    case artistError(ArtistError)
+    case unknownError(description: String)
+    
+    public init(error: Error) {
+        if let artistError = error as? ArtistError {
+            self = .artistError(artistError)
+        } else if let noteError = error as? NoteError {
+            self = .noteError(noteError)
+        } else {
+            self = .unknownError(description: error.localizedDescription)
+        }
+    }
+    
+    public var errorDescription: String {
+        switch self {
+        case .noteError(let noteError):
+            return noteError.errorDescription
+        case .artistError(let artistError):
+            return artistError.errorDescription
+        case .unknownError(let description):
+            return description
+        }
+    }
+}

--- a/Projects/Feature/Main/Interface/Sources/ViewControllers/CommunityMainViewController.swift
+++ b/Projects/Feature/Main/Interface/Sources/ViewControllers/CommunityMainViewController.swift
@@ -1,0 +1,411 @@
+//
+//  CommunityMainViewController.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import Domain
+import FlexLayout
+import Shared
+
+import Combine
+import UIKit
+
+public final class CommunityMainViewController: UIViewController, NoteMenuHandling, NoteMusicHandling {
+    var viewModel: CommunityMainViewModel
+    
+    private var cancellables: Set<AnyCancellable> = .init()
+    private let navigationBarHeight: CGFloat = 44
+    
+    // MARK: - Keychain
+    
+    @KeychainWrapper<UserInformation>(.userInfo)
+    public var userInfo
+    
+    // MARK: - UI Components
+    
+    private let flexContainer = UIView()
+    private let communityMainView: CommunityMainView = .init()
+    private let navigationBar = NavigationBar()
+    
+    private let navigationBackgroundView = UIView()
+    
+    private let backButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(FeelinImages.backLight, for: .normal)
+
+        return button
+    }()
+    
+    private let notificationButton: UIButton = {
+        let button = UIButton()
+        button.setImage(FeelinImages.notificationLightOff, for: .normal)
+        
+        return button
+    }()
+    
+    private lazy var titleLabel: UILabel = { [unowned self] in
+        let label = UILabel()
+        label.text = "\(self.viewModel.artist.name) 레코드"
+        label.font = SharedDesignSystemFontFamily.Pretendard.bold.font(size: 18)
+        label.textColor = Colors.gray09
+        
+        return label
+    }()
+    
+    // MARK: - NoteMenu Subjects
+    
+    public let onReportNote: PassthroughSubject<Int, Never> = .init()
+    public let onEditNote: PassthroughSubject<Int, Never> = .init()
+    public let onDeleteNote: PassthroughSubject<Int, Never> = .init()
+    
+    // MARK: - DiffableDataSource
+    
+    private typealias CommunityMainDataSource = UICollectionViewDiffableDataSource<Section, Row>
+    
+    private enum Section: Hashable {
+        case artist
+        case notes
+    }
+    
+    private enum Row: Hashable {
+        case artist(Artist)
+        case note(Note)
+        case emptyNote
+    }
+    
+    private lazy var communityMainDataSource: CommunityMainDataSource = {
+        let dataSource = CommunityMainDataSource(collectionView: self.communityMainCollectionView) { [weak self] collectionView, indexPath, item in
+            guard let self = self else {
+                return nil
+            }
+            
+            switch item {
+            case .artist(let artist):
+                let cell = collectionView.dequeueReusableCell(
+                    for: indexPath,
+                    cellType: CommunityArtistCell.self
+                )
+                
+                cell.configure(self.viewModel.artist)
+                
+                cell.favoriteArtistSelectButton.publisher(for: .touchUpInside)
+                    .debounce(
+                        for: .milliseconds(600),
+                        scheduler: DispatchQueue.main
+                    )
+                    .sink { control in
+                        self.viewModel.setFavoriteArtist(control.isSelected)
+                    }
+                    .store(in: &cancellables)
+                
+                return cell
+                
+            case .emptyNote:
+                let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: EmptyNoteCell.self)
+                
+                return cell
+                
+            case .note(let note):
+                let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: NoteCell.self)
+                cell.configure(with: note)
+                
+                cell.likeNoteButton.publisher(for: .touchUpInside)
+                    .debounce(for: .milliseconds(600), scheduler: DispatchQueue.main)
+                    .sink { [weak self] control in
+                        self?.viewModel.setNoteLikeState(
+                            noteID: note.id,
+                            isLiked: control.isSelected
+                        )
+                    }
+                    .store(in: &self.cancellables)
+                
+                cell.bookmarkButton.publisher(for: .touchUpInside)
+                    .debounce(
+                        for: .milliseconds(600),
+                        scheduler: DispatchQueue.main
+                    )
+                    .sink { control in
+                        self.viewModel.setNoteBookmarkState(
+                            noteID: note.id,
+                            isBookmarked: control.isSelected
+                        )
+                    }
+                    .store(in: &self.cancellables)
+                
+                cell.moreAboutContentButton.publisher(for: .touchUpInside)
+                    .sink { _ in
+                        if let noteMenuViewController = self.makeNoteMenuViewController(checking: note) {
+                            self.present(noteMenuViewController, animated: false)
+                        } else {
+                            // TODO: - 비회원 알림을 추후 보여줘야 한다.
+                        }
+                    }
+                    .store(in: &self.cancellables)
+                
+                cell.playMusicButton.publisher(for: .touchUpInside)
+                    .throttle(
+                        for: .milliseconds(600),
+                        scheduler: DispatchQueue.main,
+                        latest: false
+                    )
+                    .sink { _ in
+                        self.openYouTube(query: "\(note.song.artist.name) \(note.song.name)")
+                    }
+                    .store(in: &self.cancellables)
+                
+                return cell
+            }
+        }
+        
+        dataSource.supplementaryViewProvider = { [unowned self] (collectionView, kind, indexPath) in
+            switch kind {
+            case CommunityNoteHeaderView.reuseIdentifier:
+                let communityNoteHeaderView = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    for: indexPath,
+                    viewType: CommunityNoteHeaderView.self
+                )
+                
+                communityNoteHeaderView.includeNoteButton.publisher(for: .touchUpInside)
+                    .map(\.isSelected)
+                    .assign(to: &viewModel.$mustHaveLyrics)
+                
+                return communityNoteHeaderView
+                
+            default:
+                return UICollectionReusableView()
+            }
+        }
+        
+        return dataSource
+    }()
+
+    // MARK: - Init
+    
+    public init(viewModel: CommunityMainViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: .main)
+    }
+    
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        self.setUpNagivationBar()
+        self.setUpLayout()
+        self.bindUI()
+        self.bindAction()
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+    
+    public override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        
+        flexContainer.pin.all()
+        flexContainer.flex.layout()
+    }
+    
+    // MARK: - SetUp
+    
+    private func setUpNagivationBar() {
+        self.navigationBar.addLeftBarView(backButton)
+        self.navigationBar.addTitleView(titleLabel)
+        self.navigationBar.addRightBarView(notificationButton)
+        self.navigationBar.changeBackgroundColor(.clear)
+        self.navigationBar.hideTitleView(true)
+    }
+    
+    private func setUpLayout() {
+        self.view.backgroundColor = Colors.background
+        self.view.addSubview(flexContainer)
+        
+        flexContainer.flex.define { flex in
+            flex.addItem(communityMainView)
+                .top(-UIApplication.shared.safeAreaInsets.top)
+                .grow(1)
+            
+            flex.addItem(navigationBackgroundView)
+                .backgroundColor(Colors.background)
+                .position(.absolute)
+                .width(100%)
+                .height(UIApplication.shared.safeAreaInsets.top)
+            
+            flex.addItem(navigationBar)
+                .position(.absolute)
+                .width(100%)
+                .height(self.navigationBarHeight)
+                .top(UIApplication.shared.safeAreaInsets.top)
+        }
+    }
+    
+    // MARK: - CollectionView Snapshot
+    
+    private func updateArtistUI(_ artist: Artist) {
+        var snapshot = communityMainDataSource.snapshot()
+        
+        if !snapshot.sectionIdentifiers.contains(.artist) {
+            snapshot.appendSections([.artist])
+            snapshot.appendItems(
+                [.artist(artist)],
+                toSection: .artist
+            )
+            communityMainDataSource.apply(snapshot)
+            
+        } else {
+            let currentItems = snapshot.itemIdentifiers(inSection: .artist)
+            snapshot.deleteItems(currentItems)
+            snapshot.appendItems([.artist(artist)], toSection: .artist)
+            let newItems = snapshot.itemIdentifiers(inSection: .artist)
+            snapshot.reconfigureItems(newItems)
+            communityMainDataSource.apply(snapshot, animatingDifferences: false)
+        }
+    }
+    
+    private var shouldUpdate: Bool = true
+    
+    private func updateNotesUI(_ notes: [Note]) {
+        // TODO: - 정상작동 X, 수정 필요 p1
+        var snapshot = communityMainDataSource.snapshot()
+        let newNoteItems = notes.map { Row.note($0) }
+        
+        // notes 섹션이 있는 경우
+        if snapshot.sectionIdentifiers.contains(.notes) {
+            let currentItems = snapshot.itemIdentifiers(inSection: .notes)
+            
+            if notes.isEmpty {
+                // notes가 비어있으면 Row.emptyNote를 추가
+                if !currentItems.contains(.emptyNote) {
+                    snapshot.deleteItems(currentItems)
+                    snapshot.appendItems([.emptyNote], toSection: .notes)
+                }
+            } else {
+                // notes가 1개 이상이면 Row.emptyNote를 삭제하고 notes를 추가
+                if currentItems.contains(.emptyNote) {
+                    snapshot.deleteItems([.emptyNote])
+                }
+
+                // 기존 노트 항목과 새로운 항목이 다를 경우 업데이트
+                if currentItems != newNoteItems {
+                    snapshot.deleteItems(currentItems)
+                    snapshot.appendItems(newNoteItems, toSection: .notes)
+                }
+            }
+            
+            let itemCountChanged = notes.count != currentItems.count
+            if !itemCountChanged {
+                snapshot.reconfigureItems(newNoteItems)
+            }
+            
+            communityMainDataSource.apply(snapshot, animatingDifferences: false)
+            
+
+        } else {
+            // notes 섹션이 처음 추가될 때
+            snapshot.appendSections([.notes])
+            
+            if notes.isEmpty {
+                // notes가 비어있으면 Row.emptyNote 추가
+                snapshot.appendItems([.emptyNote], toSection: .notes)
+            } else {
+                // notes가 있으면 Row.note 추가
+                snapshot.appendItems(notes.map { Row.note($0) }, toSection: .notes)
+            }
+
+            communityMainDataSource.apply(snapshot, animatingDifferences: false)
+        }
+        
+        if self.communityMainCollectionView.refreshControl!.isRefreshing {
+            self.communityMainCollectionView.refreshControl?.endRefreshing()
+        }
+        
+    }
+}
+
+// MARK: - Bindings
+
+private extension CommunityMainViewController {
+    func bindUI() {
+        self.viewModel.$artist
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] updatedArtist in
+                self?.updateArtistUI(updatedArtist)
+            }
+            .store(in: &cancellables)
+        
+        self.viewModel.$fetchedNotes
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] updatedNotes in
+                self?.updateNotesUI(updatedNotes)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$error
+            .compactMap { $0 }
+            .sink { [weak self] error in
+                self?.showAlert(
+                    title: error.errorDescription,
+                    message: nil,
+                    singleActionTitle: "확인"
+                )
+            }
+            .store(in: &cancellables)
+    }
+    
+    func bindAction() {
+        self.communityMainCollectionView.contentOffsetPublisher
+            .removeDuplicates()
+            .sink { [weak self] scrollOffset in
+                self?.navigationBarOnScroll(yOffset: scrollOffset.y)
+            }
+            .store(in: &cancellables)
+        
+        communityMainCollectionView.didScrollToBottomPublisher()
+            .sink { [weak viewModel] in
+                viewModel?.getArtistNotes(isInitial: false)
+            }
+            .store(in: &cancellables)
+        
+        communityMainCollectionView.refreshControl?.isRefreshingPublisher
+            .filter { $0 }
+            .sink(receiveValue: { [weak viewModel] _ in
+                viewModel?.getArtistNotes(isInitial: true)
+                
+            })
+            .store(in: &cancellables)
+    }
+    
+    private func navigationBarOnScroll(yOffset: CGFloat) {
+        let artistSectionMaxYOffset = CommunityMainView.artistSectionHeight - UIApplication.shared.safeAreaInsets.top
+        
+        // 아티스트 섹션보다 더 스크롤 할 경우
+        if yOffset >= artistSectionMaxYOffset {
+            self.navigationBar.changeBackgroundColor(Colors.background)
+            self.navigationBackgroundView.flex.backgroundColor(Colors.background)
+            self.navigationBar.hideTitleView(false)
+            self.navigationBar.hideRightBarView(true)
+        } else {
+            self.navigationBar.changeBackgroundColor(.clear)
+            self.navigationBackgroundView.flex.backgroundColor(.clear)
+            self.navigationBar.hideTitleView(true)
+            self.navigationBar.hideRightBarView(false)
+        }
+    }
+}
+
+private extension CommunityMainViewController {
+    var communityMainCollectionView: UICollectionView {
+        return self.communityMainView.communityMainCollectionView
+    }
+}

--- a/Projects/Feature/Main/Interface/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Feature/Main/Interface/Sources/ViewControllers/HomeViewController.swift
@@ -218,6 +218,7 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     }
     
     private func updateNotes(_ notes: [Note]) {
+        // TODO: - 정상작동 X, 수정 필요 p1
         var snapshot = homeDataSource.snapshot()
         
         // notes 섹션이 있는 경우

--- a/Projects/Feature/Main/Interface/Sources/Views/Cells+SupplementaryViews/CommunityArtistCell.swift
+++ b/Projects/Feature/Main/Interface/Sources/Views/Cells+SupplementaryViews/CommunityArtistCell.swift
@@ -1,0 +1,115 @@
+//
+//  CommunityArtistCell.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import Domain
+import Shared
+
+import UIKit
+
+class CommunityArtistCell: UICollectionViewCell, Reusable {
+    
+    // MARK: - UI
+    
+    private let artistImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.isUserInteractionEnabled = true
+        
+        return imageView
+    }()
+    
+    private let recordLabel: UILabel = {
+        let label = UILabel()
+        label.font = SharedDesignSystemFontFamily.Pretendard.bold.font(size: 24)
+        label.textColor = .white
+        
+        return label
+    }()
+    
+    private (set) var favoriteArtistSelectButton: FavoriteArtistSelectButton = .init()
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setUpLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.artistImageView.pin.all()
+        self.artistImageView.flex.layout()
+    }
+    
+    // MARK: - Layout
+    
+    private func setUpLayout() {
+        self.addSubview(artistImageView)
+        
+        artistImageView
+            .flex
+            .alignItems(.center)
+            .justifyContent(.end)
+            .paddingBottom(28)
+            .define { flex in
+                flex.addItem(recordLabel)
+                    .marginBottom(20)
+                
+                flex.addItem(favoriteArtistSelectButton)
+                    .minHeight(38)
+            }
+    }
+    
+    func configure(_ artist: Artist) {
+        self.artistImageView.kf.setImage(with: try? artist.imageSource?.asURL())
+        self.recordLabel.text = "\(artist.name) 레코드"
+        self.favoriteArtistSelectButton.isSelected = artist.isFavorite
+        self.recordLabel.flex.markDirty()
+        self.artistImageView.kf.setImage(with: try? artist.imageSource?.asURL()) { result in
+                switch result {
+                case .success:
+                    self.artistImageView.flex.markDirty()
+                    self.artistImageView.flex.layout()
+                case .failure(let error):
+                    print("Error loading image: \(error)")
+                }
+            }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.artistImageView.image = nil
+        self.recordLabel.text = nil
+        self.favoriteArtistSelectButton = FavoriteArtistSelectButton()
+        self.recordLabel.text = nil
+        self.recordLabel.text = nil
+        self.artistImageView.image = nil
+    }
+}
+
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct CommunityArtistCell_Preview: PreviewProvider {
+    static var previews: some View {
+        CommunityArtistCell(
+            frame: .init(
+                x: 0,
+                y: 0,
+                width: 117,
+                height: 300
+            )
+        ).showPreview()
+    }
+}
+
+#endif

--- a/Projects/Feature/Main/Interface/Sources/Views/Cells+SupplementaryViews/CommunityNoteHeaderView.swift
+++ b/Projects/Feature/Main/Interface/Sources/Views/Cells+SupplementaryViews/CommunityNoteHeaderView.swift
@@ -1,0 +1,74 @@
+//
+//  CommunityNoteHeaderView.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import FlexLayout
+import Shared
+
+import UIKit
+
+class CommunityNoteHeaderView: UICollectionReusableView, Reusable {
+    
+    // MARK: - UI components
+    
+    private var flexContainer = UIView()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "노트"
+        label.font = SharedDesignSystemFontFamily.Pretendard.bold.font(size: 18)
+        label.textColor = Colors.gray09
+        
+        return label
+    }()
+    
+    private (set) var includeNoteButton: IncludeNoteButton = .init()
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.setUpLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        flexContainer.pin.all()
+        flexContainer.flex.layout()
+    }
+    
+    private func setUpLayout() {
+        self.addSubview(flexContainer)
+        
+        flexContainer.flex
+            .paddingVertical(20)
+            .define { flex in
+                flex.addItem()
+                    .direction(.row)
+                    .define { flex in
+                        flex.addItem(titleLabel)
+                            .paddingRight(3)
+                            .grow(1)
+                        
+                        flex.addItem(includeNoteButton)
+                    }
+                    .paddingHorizontal(20)
+                
+                flex.addItem()
+                    .height(1)
+                    .width(100%)
+                    .backgroundColor(Colors.backgroundTertiary)
+                    .marginTop(20)
+            }
+    }
+}

--- a/Projects/Feature/Main/Interface/Sources/Views/Cells+SupplementaryViews/NoteCell.swift
+++ b/Projects/Feature/Main/Interface/Sources/Views/Cells+SupplementaryViews/NoteCell.swift
@@ -135,7 +135,6 @@ final class NoteCell: UICollectionViewCell, Reusable {
         return button
     }()
     
-    
     // MARK: - Init
     
     override init(frame: CGRect) {
@@ -240,6 +239,7 @@ final class NoteCell: UICollectionViewCell, Reusable {
     }
     
     // MARK: - Configure UI
+    
     func configure(with note: Note, showsFullNoteContents: Bool = false) {
         self.authorCharacterImageView.image = note.publisher.profileCharacterType.image
         self.authorNameLabel.text = note.publisher.nickname
@@ -275,6 +275,8 @@ final class NoteCell: UICollectionViewCell, Reusable {
         self.flexContainer.flex.layout()
     }
     
+    // MARK: - Prepare for Reuse
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         
@@ -287,10 +289,60 @@ final class NoteCell: UICollectionViewCell, Reusable {
         self.artistNameLabel.text = nil
         self.likeAmountLabel.text = nil
         self.commentAmountLabel.text = nil
-        self.likeNoteButton.isSelected = false
-        self.bookmarkButton.isSelected = false
+        self.likeNoteButton = self.makeLikeNoteButton()
+        self.bookmarkButton = self.makeBookmarkButton()
+        self.commentButton = self.makeCommentButton()
+        self.playMusicButton = self.makePlayMusicButton()
+        self.moreAboutContentButton = self.makeMoreAboutContentButton()
         self.lyricsContentsView.configureView(with: nil)
         self.flexContainer.flex.layout()
+    }
+    
+    // MARK: - Button Make functions
+    
+    private func makeBookmarkButton() -> FeelinSelectableImageButton {
+        let button = FeelinSelectableImageButton(
+            selectedImage: FeelinImages.bookmarkActiveLight,
+            unSelectedImage: FeelinImages.bookmarkInactiveLight
+        )
+        
+        return button
+    }
+    
+    private func makeCommentButton() -> UIButton {
+        let button = UIButton()
+        button.setImage(FeelinImages.chatLight, for: .normal)
+        
+        return button
+    }
+    
+    private func makeLikeNoteButton() -> FeelinSelectableImageButton {
+        let button = FeelinSelectableImageButton(
+            selectedImage: FeelinImages.heartActiveLight,
+            unSelectedImage: FeelinImages.heartInactiveLight
+        )
+        
+        return button
+    }
+    
+    private func makePlayMusicButton() -> UIButton {
+        let button = UIButton()
+        let buttonImage = FeelinImages.play
+            .withRenderingMode(.alwaysTemplate)
+        button.setImage(buttonImage, for: .normal)
+        button.tintColor = Colors.gray03
+        
+        return button
+    }
+    
+    private func makeMoreAboutContentButton() -> UIButton {
+        let button = UIButton()
+        let buttonImage = FeelinImages.meetball
+            .withRenderingMode(.alwaysTemplate)
+        button.setImage(buttonImage, for: .normal)
+        button.tintColor = Colors.gray03
+        
+        return button
     }
     
     

--- a/Projects/Feature/Main/Interface/Sources/Views/CommunityMainView.swift
+++ b/Projects/Feature/Main/Interface/Sources/Views/CommunityMainView.swift
@@ -1,0 +1,139 @@
+//
+//  CommunityMainView.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import Shared
+
+import UIKit
+
+class CommunityMainView: UIView {
+    
+    // MARK: - UI Components
+    
+    private (set) var communityMainCollectionView: UICollectionView = {
+        let compositionalLayout = UICollectionViewCompositionalLayout { (sectionIndex, environment) -> NSCollectionLayoutSection? in
+            switch sectionIndex {
+            case CommunityMainView.artistSectionIndex:
+                return CommunityMainView.createArtistSection()
+                
+            case CommunityMainView.noteSectionIndex:
+                return CommunityMainView.createNotesSection()
+                
+            default:
+                return nil
+            }
+        }
+        
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: compositionalLayout
+        )
+        let refreshControl = UIRefreshControl()
+        collectionView.refreshControl = refreshControl
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.register(cellType: CommunityArtistCell.self)
+        collectionView.register(cellType: NoteCell.self)
+        collectionView.register(cellType: EmptyNoteCell.self)
+        collectionView.register(
+            supplementaryViewType: CommunityNoteHeaderView.self,
+            ofKind: CommunityNoteHeaderView.reuseIdentifier
+        )
+        
+        return collectionView
+    }()
+    
+    // MARK: - Init
+    
+    init() {
+        super.init(frame: .zero)
+        addSubview(communityMainCollectionView)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        communityMainCollectionView.refreshControl?.bounds = CGRect(
+            x: communityMainCollectionView.refreshControl?.bounds.minX ?? 0,
+            y: -UIApplication.shared.safeAreaInsets.top,
+            width: communityMainCollectionView.refreshControl?.bounds.width ?? 0,
+            height: communityMainCollectionView.refreshControl?.bounds.height ?? 0
+        )
+        communityMainCollectionView.pin.all()
+    }
+}
+
+extension CommunityMainView {
+    static let artistSectionIndex = 0
+    static let noteSectionIndex = 1
+    static let artistSectionHeight: CGFloat = 390
+    
+    static func createArtistSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(Self.artistSectionHeight)
+        )
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(Self.artistSectionHeight)
+        )
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+    
+    static func createNotesSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(300)
+        )
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(300)
+        )
+        
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        group.contentInsets = .init(
+            top: 0,
+            leading: 20,
+            bottom: 0,
+            trailing: 20
+        )
+        
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(64)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: CommunityNoteHeaderView.reuseIdentifier,
+            alignment: .top
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.boundarySupplementaryItems = [header]
+        return section
+    }
+}

--- a/Projects/Feature/Main/Interface/Sources/Views/Components/FavoriteArtistSelectButton.swift
+++ b/Projects/Feature/Main/Interface/Sources/Views/Components/FavoriteArtistSelectButton.swift
@@ -1,0 +1,123 @@
+//
+//  FavoriteArtistSelectButton.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import Shared
+
+import UIKit
+
+class FavoriteArtistSelectButton: UIButton {
+    
+    // MARK: - UI Components
+    
+    private let flexContainer: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        
+        return view
+    }()
+    
+    private let titleLabelView: UILabel = {
+        let label = UILabel()
+        label.text = "관심 아티스트"
+        label.font = SharedDesignSystemFontFamily.Pretendard.medium.font(size: 12)
+        label.textColor = .white
+        
+        return label
+    }()
+    
+    private let heartImageView = UIImageView()
+    private let heartRateImageWidth: CGFloat = 24
+
+    private var selectedImage: UIImage = FeelinImages.heartActiveLight
+    private var unSelectedImage: UIImage = FeelinImages.heartInactiveLight
+    
+    override init(frame: CGRect = .zero) {
+        super.init(frame: frame)
+        setUpButton()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            updateButtonImage()
+        }
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        print(heartImageView.frame.width)
+        let contentWidth = heartRateImageWidth + titleLabelView.intrinsicContentSize.width + 28
+        let contentHeight = max(
+            heartRateImageWidth,
+            titleLabelView.intrinsicContentSize.height
+        ) + 16
+        return CGSize(width: contentWidth, height: contentHeight)
+    }
+
+    private func setUpButton() {
+        updateButtonImage()
+        setupLayout()
+        addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+    
+    private func setupLayout() {
+        addSubview(flexContainer)
+        
+        flexContainer.flex
+            .backgroundColor(.init(white: 0.9, alpha: 0.3))
+            .cornerRadius(8)
+            .paddingHorizontal(10)
+            .paddingVertical(8)
+            .direction(.row)
+            .alignItems(.center)
+            .define { flex in
+                flex.addItem(heartImageView)
+                    .size(heartRateImageWidth)
+                flex.addItem(titleLabelView)
+                    .marginLeft(8)
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        flexContainer.pin.all()
+        flexContainer.flex.layout()
+    }
+    
+    @objc private func buttonTapped() {
+        print("button tapped")
+        isSelected.toggle()
+        updateButtonImage()
+    }
+    
+    private func updateButtonImage() {
+        let image = isSelected ? selectedImage : unSelectedImage
+        heartImageView.image = image
+    }
+}
+
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct FavoriteArtistButton_Preview: PreviewProvider {
+    static var previews: some View {
+        FavoriteArtistSelectButton(
+            frame: .init(
+                x: 0,
+                y: 0,
+                width: 117,
+                height: 36
+            )
+        ).showPreview()
+    }
+}
+
+#endif

--- a/Projects/Feature/Main/Testing/Sources/MockGetArtistNotesUseCase.swift
+++ b/Projects/Feature/Main/Testing/Sources/MockGetArtistNotesUseCase.swift
@@ -1,0 +1,226 @@
+//
+//  MockGetArtistNotesUseCase.swift
+//  FeatureMainInterface
+//
+//  Created by 황인우 on 10/1/24.
+//
+
+import Domain
+
+import Combine
+import Foundation
+
+public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
+    private var shouldStopPagination: Bool = false
+    public init() { }
+    
+    public func execute(
+        isInitial: Bool,
+        artistID: Int,
+        perPage: Int,
+        mustHaveLyrics: Bool
+    ) -> AnyPublisher<[Note], NoteError> {
+        if isInitial {
+            return Just(
+                [
+                    Note(
+                        id: 1,
+                        content: "테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                            background: .skyblue
+                        ),
+                        publisher: .init(
+                            id: 1,
+                            nickname: "테스트유저1",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 1,
+                            name: "everything",
+                            imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                            artist: .init(
+                                id: 1,
+                                name: "검정치마",
+                                imageSource: "www.com",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    ),
+                    Note(
+                        id: 2,
+                        content: "테스트 내용입니다2.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                            background: .black
+                        ),
+                        publisher: .init(
+                            id: 1,
+                            nickname: "테스트유저2",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 1,
+                            name: "테스트 노래2",
+                            imageUrl: "1234.com",
+                            artist: .init(
+                                id: 1,
+                                name: "테스트 아티스트2",
+                                imageSource: "www.com",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    ),
+                    Note(
+                        id: 3,
+                        content: "테스트 내용입니다3.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통",
+                            background: .beige
+                        ),
+                        publisher: .init(
+                            id: 1,
+                            nickname: "테스트유저3",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 1,
+                            name: "테스트 노래3",
+                            imageUrl: "1234.com",
+                            artist: .init(
+                                id: 1,
+                                name: "테스트 아티스트3",
+                                imageSource: "www.com",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    )
+                ]
+            )
+            .setFailureType(to: NoteError.self)
+            .eraseToAnyPublisher()
+        } else {
+            if !shouldStopPagination {
+                shouldStopPagination = true
+                return Just(
+                    [
+                        Note(
+                            id: 321,
+                            content: "테스트 추가 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                                background: .skyblue
+                            ),
+                            publisher: .init(
+                                id: 321,
+                                nickname: "테스트유저1",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 321,
+                                name: "everything",
+                                imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                                artist: .init(
+                                    id: 321,
+                                    name: "검정치마",
+                                    imageSource: "www.com",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 322,
+                            content: "테스트 내용입니다2.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                                background: .black
+                            ),
+                            publisher: .init(
+                                id: 322,
+                                nickname: "테스트유저2",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 322,
+                                name: "테스트 노래2",
+                                imageUrl: "1234.com",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트2",
+                                    imageSource: "www.com",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 323,
+                            content: "테스트 내용입니다3.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통",
+                                background: .beige
+                            ),
+                            publisher: .init(
+                                id: 323,
+                                nickname: "테스트유저3",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 323,
+                                name: "테스트 노래3",
+                                imageUrl: "1234.com",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트3",
+                                    imageSource: "www.com",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        )
+                    ]
+                )
+                .setFailureType(to: NoteError.self)
+                .eraseToAnyPublisher()
+            } else {
+                return Empty()
+                    .setFailureType(to: NoteError.self)
+                    .eraseToAnyPublisher()
+            }
+        }
+    }
+}

--- a/Projects/Feature/Main/Testing/Sources/MockSetFavoriteArtistUseCase.swift
+++ b/Projects/Feature/Main/Testing/Sources/MockSetFavoriteArtistUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  MockSetFavoriteArtistUseCase.swift
+//  FeatureMainTesting
+//
+//  Created by 황인우 on 10/3/24.
+//
+
+import Domain
+
+import Combine
+import Foundation
+
+public struct MockSetFavoriteArtistUseCase: SetFavoriteArtistUseCaseInterface {
+    public init() { }
+    
+    public func execute(
+        artistID: Int,
+        isFavorite: Bool
+    ) -> AnyPublisher<Bool, ArtistError> {
+        return Just(isFavorite)
+            .setFailureType(to: ArtistError.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Feature/Main/Testing/Sources/MockSetNoteLIkeUseCase.swift
+++ b/Projects/Feature/Main/Testing/Sources/MockSetNoteLIkeUseCase.swift
@@ -17,13 +17,24 @@ public struct MockSetNoteLikeUseCase: SetNoteLikeUseCaseInterface {
         isLiked: Bool,
         noteID: Int
     ) -> AnyPublisher<NoteLike, NoteError> {
-        return Just(
-            NoteLike(
-                likesCount: 13,
-                noteID: noteID
+        return if isLiked {
+            Just(
+                NoteLike(
+                    likesCount: 13,
+                    noteID: noteID
+                )
             )
-        )
-        .setFailureType(to: NoteError.self)
-        .eraseToAnyPublisher()
+            .setFailureType(to: NoteError.self)
+            .eraseToAnyPublisher()
+        } else {
+            Just(
+                NoteLike(
+                    likesCount: 0,
+                    noteID: noteID
+                )
+            )
+            .setFailureType(to: NoteError.self)
+            .eraseToAnyPublisher()
+        }
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Views/NavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Views/NavigationBar.swift
@@ -103,3 +103,26 @@ private extension NavigationBar {
     }
 }
 
+// MARK: - Change Navigation Bar Display
+
+public extension NavigationBar {
+    func hideRightBarView(_ mustHide: Bool) {
+        rightBarView.isHidden = mustHide
+        rootFlexContainer.flex.layout()
+    }
+    
+    func hideTitleView(_ mustHide: Bool) {
+        titleView.isHidden = mustHide
+        rootFlexContainer.flex.layout()
+    }
+    
+    func hideLeftView(_ mustHide: Bool) {
+        leftBarView.isHidden = mustHide
+        rootFlexContainer.flex.layout()
+    }
+    
+    func changeBackgroundColor(_ color: UIColor) {
+        self.backgroundColor = color
+        rootFlexContainer.flex.layout()
+    }
+}

--- a/Projects/Shared/Util/Sources/Extensions/UIApplication+.swift
+++ b/Projects/Shared/Util/Sources/Extensions/UIApplication+.swift
@@ -1,0 +1,16 @@
+//
+//  UIApplication+.swift
+//  SharedUtil
+//
+//  Created by 황인우 on 10/3/24.
+//
+
+import UIKit
+
+public extension UIApplication {
+    var safeAreaInsets: UIEdgeInsets {
+        let windowScene = self.connectedScenes.first as? UIWindowScene
+        let window = windowScene?.windows.first
+        return window?.safeAreaInsets ?? .zero
+    }
+}


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [x] 버그 수정
- [x] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경
커뮤니티 메인 화면 및 기능이 필요합니다.

## 목표
- 아티스트 사진이 상단 safearea를 무시하여 상단을 꽉 채줘야 합니다.
- 스크롤 시 navigationBar의 UI가 변경되어야 합니다.
- 아티스트 관련 노트 리스트를 확인할 수 있어야 합니다.

## 결과 (Optional)
![Simulator Screen Recording - iPhone 15 Pro - 2024-10-05 at 11 07 06](https://github.com/user-attachments/assets/1b68f51e-040e-4bdb-9a3a-801d6437aaa5)


## TroubleShooting
notecell의 버튼들의 publisher들은 재사용되기 전까지는 터치시 한 번의 이벤트만을 방출하였으나. 스크롤에 의한 데이터 추가로 인해 cell이 재사용될 때 기존 publisher들이 남아있어서 이벤트를 중복으로 방출하는 문제가 있었습니다.
`prepareForReuse()` 메서드 내부에서 버튼을 재 생성하는 방식으로 해당 문제를 해결하였습니다.
