### PR TITLE
Fix/ 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면의 collectionView관련 버그 수정

### DIFF
--- a/Projects/Feature/Home/Example/Sources/SceneDelegate.swift
+++ b/Projects/Feature/Home/Example/Sources/SceneDelegate.swift
@@ -189,7 +189,7 @@ extension SceneDelegate {
 //        
 //        window?.rootViewController = HomeViewController(viewModel: homeViewModel)
 //        window?.makeKeyAndVisible()
-//         --------------------MainViewController-------------------
+//         --------------------HomeViewController-------------------
         
 //        DIContainer.standard.register(.networkProvider) { _ in
 //            return NetworkProvider(
@@ -252,13 +252,21 @@ extension SceneDelegate {
 //            imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
 //            noteCount: 1
 //        )
+////        
+////        let noteDetailViewModel = NoteDetailViewModel(
+////            selectedNote: selectedNote,
+////            getSongNotesUseCase: getSongNotesUseCase,
+////            setNoteLikeUseCase: setNoteLikeUseCase,
+////            setBookmarkUseCase: setBookmarkUseCase,
+////            deleteNoteUseCase: deleteNoteUseCase
+////        )
 //        
 //        let noteDetailViewModel = NoteDetailViewModel(
 //            selectedNote: selectedNote,
-//            getSongNotesUseCase: getSongNotesUseCase,
-//            setNoteLikeUseCase: setNoteLikeUseCase,
-//            setBookmarkUseCase: setBookmarkUseCase,
-//            deleteNoteUseCase: deleteNoteUseCase
+//            getSongNotesUseCase: MockGetSongNotesUseCase(),
+//            setNoteLikeUseCase: MockSetNoteLikeUseCase(),
+//            setBookmarkUseCase: MockSetBookmarkUseCase(),
+//            deleteNoteUseCase: MockDeleteNoteUseCase()
 //        )
 //        
 //        window?.rootViewController = NoteDetailViewController(viewModel: noteDetailViewModel)
@@ -269,17 +277,17 @@ extension SceneDelegate {
 //        @KeychainWrapper<UserInformation>(.userInfo)
 //        var userInfo
 //        
-//        userInfo = .init(userID: 4)
+//        userInfo = .init(userID: 2)
 //        
-////        let noteCommentsViewModel = NoteCommentsViewModel(
-////            noteID: 1,
-////            setNoteLikeUseCase: MockSetNoteLikeUseCase(),
-////            setBookmarkUseCase: MockSetBookmarkUseCase(),
-////            deleteNoteUseCase: MockDeleteNoteUseCase(),
-////            getNoteWithCommentsUseCase: MockGetNoteWithCommentsUseCase(),
-////            writeCommentUseCase: MockWriteCommentUseCase(),
-////            deleteCommentUseCase: MockDeleteCommentUseCase()
-////        )
+//        let noteCommentsViewModel = NoteCommentsViewModel(
+//            noteID: 1,
+//            setNoteLikeUseCase: MockSetNoteLikeUseCase(),
+//            setBookmarkUseCase: MockSetBookmarkUseCase(),
+//            deleteNoteUseCase: MockDeleteNoteUseCase(),
+//            getNoteWithCommentsUseCase: MockGetNoteWithCommentsUseCase(),
+//            writeCommentUseCase: MockWriteCommentUseCase(),
+//            deleteCommentUseCase: MockDeleteCommentUseCase()
+//        )
 //        DIContainer.standard.register(.networkProvider) { _ in
 //            return NetworkProvider(networkSession: .init(requestInterceptor: MockTokenInterceptor()))
 //        }
@@ -298,24 +306,45 @@ extension SceneDelegate {
 //        @Injected(.noteAPIService) var noteAPIService: NoteAPIServiceInterface
 //        @Injected(.commentAPIService) var commentAPIService: CommentAPIServiceInterface
 //        
-//        let noteCommentsViewModel = NoteCommentsViewModel(
-//            noteID: 3,
-//            setNoteLikeUseCase: SetNoteLikeUseCase(noteAPIService: noteAPIService),
-//            setBookmarkUseCase: SetBookmarkUseCase(noteAPIService: noteAPIService),
-//            deleteNoteUseCase: DeleteNoteUseCase(noteAPIService: noteAPIService),
-//            getNoteWithCommentsUseCase: GetNoteWithCommentsUseCase(commentAPIService: commentAPIService),
-//            writeCommentUseCase: WriteCommentUseCase(commentAPIService: commentAPIService),
-//            deleteCommentUseCase: DeleteCommentUseCase(commentAPIService: commentAPIService)
-//        )
+////        let noteCommentsViewModel = NoteCommentsViewModel(
+////            noteID: 3,
+////            setNoteLikeUseCase: SetNoteLikeUseCase(noteAPIService: noteAPIService),
+////            setBookmarkUseCase: SetBookmarkUseCase(noteAPIService: noteAPIService),
+////            deleteNoteUseCase: DeleteNoteUseCase(noteAPIService: noteAPIService),
+////            getNoteWithCommentsUseCase: GetNoteWithCommentsUseCase(commentAPIService: commentAPIService),
+////            writeCommentUseCase: WriteCommentUseCase(commentAPIService: commentAPIService),
+////            deleteCommentUseCase: DeleteCommentUseCase(commentAPIService: commentAPIService)
+////        )
 //        
 //        window?.rootViewController = NoteCommentsViewController(viewModel: noteCommentsViewModel)
 //        window?.makeKeyAndVisible()
         
         // --------------------NoteCommentsViewController-------------------
+//        @KeychainWrapper<UserInformation>(.userInfo)
+//        var userInfo
+//        
+//        userInfo = .init(userID: 2)
+//        
+//        let communityMainViewModel = CommunityMainViewModel(
+//            artist: dummyArtist,
+//            getArtistNotesUseCase: MockGetArtistNotesUseCase(),
+//            setNoteLikeUseCase: MockSetNoteLikeUseCase(),
+//            setBookmarkUseCase: MockSetBookmarkUseCase(),
+//            deleteNoteUseCase: MockDeleteNoteUseCase(),
+//            setFavoriteArtistUseCase: MockSetFavoriteArtistUseCase()
+//        )
+//        
+//        window?.rootViewController = CommunityMainViewController(viewModel: communityMainViewModel)
+//        window?.makeKeyAndVisible()
+        // --------------------CommunityMainViewController-------------------
     }
 }
 
 extension SceneDelegate: PostNoteViewControllerDelegate, SearchSongViewControllerDelegate {
+    func popRootViewController() {
+        
+    }
+    
     func dismissViewController() {
         
     }

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/NoteCommentsViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/NoteCommentsViewModel.swift
@@ -105,22 +105,6 @@ public final class NoteCommentsViewModel {
         }
         .store(in: &cancellables)
     }
-    
-    func deleteComment(commentID: Int) {
-        self.deleteCommentUseCase.execute(commentID: commentID)
-            .receive(on: DispatchQueue.main)
-            .mapToResult()
-            .sink { [weak self] result in
-                switch result {
-                case .success:
-                    self?.fetchNoteWithComments()
-                    
-                case .failure(let noteError):
-                    self?.error = noteError
-                }
-            }
-            .store(in: &cancellables)
-    }
 }
 
 // MARK: - Bookmark
@@ -213,6 +197,7 @@ extension NoteCommentsViewModel {
             .sink { [weak self] result in
                 switch result {
                 case .success:
+                    // TODO: - pop 해야 하나??
                     self?.fetchedNotes.removeAll(where: { $0.id == id })
                     
                 case .failure(let noteError):
@@ -233,7 +218,7 @@ extension NoteCommentsViewModel {
             .sink { [weak self] result in
                 switch result {
                 case .success:
-                    self?.fetchNoteWithComments()
+                    self?.fetchedComments.removeAll(where: { $0.id == id })
                     
                 case .failure(let noteError):
                     self?.error = noteError

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommentCell.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommentCell.swift
@@ -5,15 +5,18 @@
 //  Created by 황인우 on 9/10/24.
 //
 
+import Combine
 import UIKit
 
 import Domain
 import Shared
 
 final class CommentCell: UICollectionViewCell, Reusable {
-    private let flexContainer = UIView()
+    var cancellables: Set<AnyCancellable> = .init()
     
     // MARK: - UI Components
+    
+    private let flexContainer = UIView()
     
     private let authorCharacterImageView: UIImageView = {
         let imageView = UIImageView()
@@ -78,9 +81,10 @@ final class CommentCell: UICollectionViewCell, Reusable {
     
     private func setUpLayout() {
         addSubview(flexContainer)
-        contentView.backgroundColor = Colors.background
 
-        flexContainer.flex.define { flex in
+        flexContainer.flex
+            .backgroundColor(Colors.background)
+            .define { flex in
             // 작성자 정보 row
             flex.addItem().direction(.row).define { flex in
                 flex.addItem(authorCharacterImageView)
@@ -111,10 +115,14 @@ final class CommentCell: UICollectionViewCell, Reusable {
         self.authorNameLabel.text = comment.writer.nickname
         self.commentWrittenTimeLabel.text = comment.createdAt.formattedTimeInterval()
         self.commentContentLabel.text = comment.content
+        self.authorNameLabel.flex.markDirty()
+        self.commentWrittenTimeLabel.flex.markDirty()
+        self.commentContentLabel.flex.markDirty()
+        
+        self.flexContainer.flex.layout()
     }
     
     func configureBackgroundColor(_ backgroundColor: UIColor) {
-        
         self.flexContainer.backgroundColor = backgroundColor
     }
     
@@ -124,6 +132,7 @@ final class CommentCell: UICollectionViewCell, Reusable {
         self.authorCharacterImageView.image = nil
         self.authorNameLabel.text = nil
         self.commentContentLabel.text = nil
+        self.cancellables = .init()
         self.flexContainer.flex.layout()
     }
     

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommentCell.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommentCell.swift
@@ -80,10 +80,10 @@ final class CommentCell: UICollectionViewCell, Reusable {
     }
     
     private func setUpLayout() {
+        self.contentView.backgroundColor = Colors.background
         addSubview(flexContainer)
 
         flexContainer.flex
-            .backgroundColor(Colors.background)
             .define { flex in
             // 작성자 정보 row
             flex.addItem().direction(.row).define { flex in
@@ -123,7 +123,7 @@ final class CommentCell: UICollectionViewCell, Reusable {
     }
     
     func configureBackgroundColor(_ backgroundColor: UIColor) {
-        self.flexContainer.backgroundColor = backgroundColor
+        self.contentView.backgroundColor = backgroundColor
     }
     
     override func prepareForReuse() {

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommunityArtistCell.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommunityArtistCell.swift
@@ -8,9 +8,11 @@
 import Domain
 import Shared
 
+import Combine
 import UIKit
 
 class CommunityArtistCell: UICollectionViewCell, Reusable {
+    var cancellables: Set<AnyCancellable> = .init()
     
     // MARK: - UI
     
@@ -94,10 +96,10 @@ class CommunityArtistCell: UICollectionViewCell, Reusable {
         super.prepareForReuse()
         self.artistImageView.image = nil
         self.recordLabel.text = nil
-        self.favoriteArtistSelectButton = FavoriteArtistSelectButton()
         self.recordLabel.text = nil
         self.recordLabel.text = nil
         self.artistImageView.image = nil
+        self.cancellables = .init()
     }
 }
 

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommunityNoteHeaderView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/CommunityNoteHeaderView.swift
@@ -8,9 +8,11 @@
 import FlexLayout
 import Shared
 
+import Combine
 import UIKit
 
 class CommunityNoteHeaderView: UICollectionReusableView, Reusable {
+    var cancellables: Set<AnyCancellable> = .init()
     
     // MARK: - UI components
     
@@ -71,5 +73,11 @@ class CommunityNoteHeaderView: UICollectionReusableView, Reusable {
                     .backgroundColor(Colors.backgroundTertiary)
                     .marginTop(20)
             }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.cancellables = .init()
     }
 }

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/FavoriteArtistsHeaderView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/FavoriteArtistsHeaderView.swift
@@ -9,9 +9,12 @@ import FlexLayout
 import PinLayout
 import Shared
 
+import Combine
 import UIKit
 
 class FavoriteArtistsHeaderView: UICollectionReusableView, Reusable {
+    var cancellables: Set<AnyCancellable> = .init()
+    
     private var flexContainer = UIView()
     
     private let titleLabel: UILabel = {
@@ -64,6 +67,11 @@ class FavoriteArtistsHeaderView: UICollectionReusableView, Reusable {
             flex.addItem(viewAllButton)
         }
         .paddingRight(20)
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.cancellables = .init()
     }
 }
 

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/NoteCell.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/NoteCell.swift
@@ -5,6 +5,7 @@
 //  Created by 황인우 on 8/3/24.
 //
 
+import Combine
 import UIKit
 
 import Domain
@@ -136,6 +137,8 @@ final class NoteCell: UICollectionViewCell, Reusable {
     }()
     
     // MARK: - Init
+    
+    var cancellables: Set<AnyCancellable> = .init()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -280,6 +283,7 @@ final class NoteCell: UICollectionViewCell, Reusable {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        self.cancellables = .init()
         
         self.backgroundColor = Colors.background
         self.authorCharacterImageView.image = nil
@@ -291,62 +295,9 @@ final class NoteCell: UICollectionViewCell, Reusable {
         self.artistNameLabel.text = nil
         self.likeAmountLabel.text = nil
         self.commentAmountLabel.text = nil
-        self.likeNoteButton = self.makeLikeNoteButton()
-        self.bookmarkButton = self.makeBookmarkButton()
-        self.commentButton = self.makeCommentButton()
-        self.playMusicButton = self.makePlayMusicButton()
-        self.moreAboutContentButton = self.makeMoreAboutContentButton()
         self.lyricsContentsView.configureView(with: nil)
         self.flexContainer.flex.layout()
     }
-    
-    // MARK: - Button Make functions
-    
-    private func makeBookmarkButton() -> FeelinSelectableImageButton {
-        let button = FeelinSelectableImageButton(
-            selectedImage: FeelinImages.bookmarkActiveLight,
-            unSelectedImage: FeelinImages.bookmarkInactiveLight
-        )
-        
-        return button
-    }
-    
-    private func makeCommentButton() -> UIButton {
-        let button = UIButton()
-        button.setImage(FeelinImages.chatLight, for: .normal)
-        
-        return button
-    }
-    
-    private func makeLikeNoteButton() -> FeelinSelectableImageButton {
-        let button = FeelinSelectableImageButton(
-            selectedImage: FeelinImages.heartActiveLight,
-            unSelectedImage: FeelinImages.heartInactiveLight
-        )
-        
-        return button
-    }
-    
-    private func makePlayMusicButton() -> UIButton {
-        let button = UIButton()
-        let buttonImage = FeelinImages.play
-            .withRenderingMode(.alwaysTemplate)
-        button.setImage(buttonImage, for: .normal)
-        button.tintColor = Colors.gray03
-        
-        return button
-    }
-    
-    private func makeMoreAboutContentButton() -> UIButton {
-        let button = UIButton()
-        let buttonImage = FeelinImages.meetball
-            .withRenderingMode(.alwaysTemplate)
-        button.setImage(buttonImage, for: .normal)
-        button.tintColor = Colors.gray03
-        
-        return button
-    }
-    
     
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         self.flexContainer.pin.width(size.width)

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/NoteDetailHeaderView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/NoteDetailHeaderView.swift
@@ -8,9 +8,11 @@
 import FlexLayout
 import Shared
 
+import Combine
 import UIKit
 
 final class NoteDetailHeaderView: UICollectionReusableView, Reusable {
+    var cancellables: Set<AnyCancellable> = .init()
     
     // MARK: - UI components
     
@@ -85,6 +87,11 @@ final class NoteDetailHeaderView: UICollectionReusableView, Reusable {
         self.noteCountLabel.flex.markDirty()
         
         self.flexContainer.flex.layout()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.cancellables = .init()
     }
 }
 

--- a/Projects/Feature/Home/Interface/Sources/Views/CommunityMainView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/CommunityMainView.swift
@@ -36,13 +36,6 @@ class CommunityMainView: UIView {
         collectionView.backgroundColor = Colors.background
 
         collectionView.showsVerticalScrollIndicator = false
-        collectionView.register(cellType: CommunityArtistCell.self)
-        collectionView.register(cellType: NoteCell.self)
-        collectionView.register(cellType: EmptyNoteCell.self)
-        collectionView.register(
-            supplementaryViewType: CommunityNoteHeaderView.self,
-            ofKind: CommunityNoteHeaderView.reuseIdentifier
-        )
         
         return collectionView
     }()

--- a/Projects/Feature/Home/Interface/Sources/Views/HomeView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/HomeView.swift
@@ -54,25 +54,6 @@ final class HomeView: UIView {
         collectionView.refreshControl = UIRefreshControl()
 
         collectionView.showsVerticalScrollIndicator = false
-
-        collectionView.register(cellType: BannerCell.self)
-        collectionView.register(cellType: FeelinArtistCell.self)
-        collectionView.register(cellType: NoteCell.self)
-        collectionView.register(cellType: EmptyNoteCell.self)
-        collectionView.register(cellType: SearchArtistCell.self)
-        collectionView.register(
-            supplementaryViewType: FavoriteArtistsHeaderView.self,
-            ofKind: FavoriteArtistsHeaderView.reuseIdentifier
-        )
-        collectionView.register(
-            supplementaryViewType: SectionDividerView.self,
-            ofKind: SectionDividerView.reuseIdentifier
-        )
-        collectionView.register(
-            supplementaryViewType: NotesHeaderView.self,
-            ofKind: NotesHeaderView.reuseIdentifier
-        )
-
         return collectionView
     }()
 
@@ -125,6 +106,7 @@ final class HomeView: UIView {
 
                 flex.addItem(homeCollectionView)
                     .grow(1)
+                    .shrink(1)
             }
     }
 }

--- a/Projects/Feature/Home/Interface/Sources/Views/NoteCommentsView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/NoteCommentsView.swift
@@ -15,9 +15,8 @@ final class NoteCommentsView: UIView {
     private var cancellables: Set<AnyCancellable> = .init()
 
     // MARK: - UI Components
-    private let rootFlexContainer = UIView()
 
-    private (set) var flexContainer = UIView()
+    private var flexContainer = UIView()
     
     private let navigationBar = NavigationBar()
 
@@ -62,15 +61,6 @@ final class NoteCommentsView: UIView {
         
         collectionView.refreshControl = UIRefreshControl()
         collectionView.backgroundColor = Colors.background
-
-        collectionView.register(cellType: NoteCell.self)
-        collectionView.register(cellType: EmptyNoteCell.self)
-        collectionView.register(cellType: CommentCell.self)
-        collectionView.register(cellType: EmptyCommentCell.self)
-        collectionView.register(
-            supplementaryViewType: CommentHeaderView.self,
-            ofKind: CommentHeaderView.reuseIdentifier
-        )
         
         collectionView.showsVerticalScrollIndicator = false
         
@@ -98,48 +88,39 @@ final class NoteCommentsView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        rootFlexContainer.pin.all(pin.safeArea)
-        rootFlexContainer.flex.layout()
-
         flexContainer.pin
-            .below(of: navigationBar)
+            .top(pin.safeArea)
             .left()
             .right()
-            .bottom()
+            .bottom(pin.safeArea)
         
-        flexContainer.flex.layout(mode: .adjustHeight)
+        flexContainer.flex.layout()
     }
     
     private func setUpLayout() {
-        self.addSubview(rootFlexContainer)
+        self.addSubview(flexContainer)
         self.backgroundColor = Colors.background
 
         navigationBar.addLeftBarView([backButton])
         navigationBar.addTitleView(naviTitleLabel)
 
-        rootFlexContainer
-            .flex
-            .direction(.column)
-            .define { rootFlex in
-                rootFlex.addItem(navigationBar)
+        flexContainer.flex
+            .define { flex in
+                flex.addItem(navigationBar)
                     .marginHorizontal(10)
                     .height(44)
 
-                rootFlex.addItem(flexContainer)
+                flex.addItem(noteCommentsCollectionView)
                     .grow(1)
-                    .define { flex in
-                        flex.addItem(noteCommentsCollectionView)
-                            .grow(1)
 
-                        flex.addItem()
-                            .height(1)
-                            .width(100%)
-                            .backgroundColor(Colors.backgroundTertiary)
+                flex.addItem()
+                    .height(1)
+                    .width(100%)
+                    .backgroundColor(Colors.backgroundTertiary)
 
-                        flex.addItem(writeCommentView)
-                            .width(100%)
-                            .minHeight(80)
-                    }
+                flex.addItem(writeCommentView)
+                    .width(100%)
+                    .minHeight(80)
             }
     }
     
@@ -161,14 +142,15 @@ final class NoteCommentsView: UIView {
             .sink { [unowned self] keyboardHeight in
                 UIView.animate(withDuration: 0.3) {
                     // 키보드 높이만큼 collectionview에 inset 부여
+                    // safeAreaInset대응하여 위치 조정하는 로직 추가
                     self.noteCommentsCollectionView.contentInset = .init(
                         top: 0,
                         left: 0,
-                        bottom: keyboardHeight,
+                        bottom: max(0, keyboardHeight - self.safeAreaInsets.bottom),
                         right: 0
                     )
                     // 키보드 높이 변경시 writeComment의 위치 조정
-                    self.writeCommentView.flex.position(.relative).bottom(keyboardHeight)
+                    self.writeCommentView.flex.position(.relative).bottom(max(0, keyboardHeight - self.safeAreaInsets.bottom))
                     
                     
                     self.flexContainer.flex.layout(mode: .adjustHeight)

--- a/Projects/Feature/Home/Interface/Sources/Views/NoteDetailView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/NoteDetailView.swift
@@ -53,13 +53,6 @@ final class NoteDetailView: UIView {
 
         collectionView.showsVerticalScrollIndicator = false
 
-        collectionView.register(cellType: SongCell.self)
-        collectionView.register(cellType: NoteCell.self)
-        collectionView.register(
-            supplementaryViewType: NoteDetailHeaderView.self,
-            ofKind: NoteDetailHeaderView.reuseIdentifier
-        )
-
         return collectionView
     }()
 

--- a/Projects/Feature/Home/Testing/Sources/DummyArtist.swift
+++ b/Projects/Feature/Home/Testing/Sources/DummyArtist.swift
@@ -1,0 +1,17 @@
+//
+//  DummyArtist.swift
+//  FeatureHomeTesting
+//
+//  Created by 황인우 on 10/9/24.
+//
+
+import Foundation
+
+import Domain
+
+public let dummyArtist = Artist(
+    id: 1,
+    name: "검정치마",
+    imageSource: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+    isFavorite: true
+)

--- a/Projects/Feature/Home/Testing/Sources/MockGetArtistNotesUseCase.swift
+++ b/Projects/Feature/Home/Testing/Sources/MockGetArtistNotesUseCase.swift
@@ -21,6 +21,7 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
         mustHaveLyrics: Bool
     ) -> AnyPublisher<[Note], NoteError> {
         if isInitial {
+            self.shouldStopPagination = false
             return Just(
                 [
                     Note(
@@ -63,18 +64,18 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
                             background: .black
                         ),
                         publisher: .init(
-                            id: 1,
+                            id: 2,
                             nickname: "테스트유저2",
                             profileCharacterType: .poopHair
                         ),
                         song: .init(
-                            id: 1,
+                            id: 2,
                             name: "테스트 노래2",
                             imageUrl: "1234.com",
                             artist: .init(
                                 id: 1,
                                 name: "테스트 아티스트2",
-                                imageSource: "www.com",
+                                imageSource: "",
                                 isFavorite: false
                             )
                         ),
@@ -93,18 +94,18 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
                             background: .beige
                         ),
                         publisher: .init(
-                            id: 1,
+                            id: 3,
                             nickname: "테스트유저3",
                             profileCharacterType: .poopHair
                         ),
                         song: .init(
-                            id: 1,
+                            id: 3,
                             name: "테스트 노래3",
-                            imageUrl: "1234.com",
+                            imageUrl: "",
                             artist: .init(
                                 id: 1,
                                 name: "테스트 아티스트3",
-                                imageSource: "www.com",
+                                imageSource: "",
                                 isFavorite: false
                             )
                         ),
@@ -143,7 +144,7 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
                                 artist: .init(
                                     id: 321,
                                     name: "검정치마",
-                                    imageSource: "www.com",
+                                    imageSource: "",
                                     isFavorite: false
                                 )
                             ),
@@ -169,11 +170,11 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
                             song: .init(
                                 id: 322,
                                 name: "테스트 노래2",
-                                imageUrl: "1234.com",
+                                imageUrl: "",
                                 artist: .init(
                                     id: 1,
                                     name: "테스트 아티스트2",
-                                    imageSource: "www.com",
+                                    imageSource: "",
                                     isFavorite: false
                                 )
                             ),
@@ -199,11 +200,11 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
                             song: .init(
                                 id: 323,
                                 name: "테스트 노래3",
-                                imageUrl: "1234.com",
+                                imageUrl: "",
                                 artist: .init(
                                     id: 1,
                                     name: "테스트 아티스트3",
-                                    imageSource: "www.com",
+                                    imageSource: "",
                                     isFavorite: false
                                 )
                             ),
@@ -211,7 +212,220 @@ public class MockGetArtistNotesUseCase: GetArtistNotesUseCaseInterface {
                             likesCount: 0,
                             isLiked: false,
                             isBookmarked: false
-                        )
+                        ),
+                        Note(
+                            id: 324,
+                            content: "테스트 내용입니다2.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                                background: .black
+                            ),
+                            publisher: .init(
+                                id: 324,
+                                nickname: "테스트유저2",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 324,
+                                name: "테스트 노래2",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트2",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 325,
+                            content: "테스트 내용입니다3.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통",
+                                background: .beige
+                            ),
+                            publisher: .init(
+                                id: 325,
+                                nickname: "테스트유저3",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 325,
+                                name: "테스트 노래3",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트3",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        
+                        Note(
+                            id: 326,
+                            content: "테스트 추가 내용입니다333.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                                background: .skyblue
+                            ),
+                            publisher: .init(
+                                id: 326,
+                                nickname: "테스트유저1",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 326,
+                                name: "everything",
+                                imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                                artist: .init(
+                                    id: 326,
+                                    name: "검정치마",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 326,
+                            content: "테스트 내용입니다2.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                                background: .black
+                            ),
+                            publisher: .init(
+                                id: 326,
+                                nickname: "테스트유저2",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 326,
+                                name: "테스트 노래2",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트2",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 327,
+                            content: "테스트 내용입니다2.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                                background: .black
+                            ),
+                            publisher: .init(
+                                id: 327,
+                                nickname: "테스트유저2",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 327,
+                                name: "테스트 노래2",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 327,
+                                    name: "테스트 아티스트2",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 328,
+                            content: "테스트 내용입니다3.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통",
+                                background: .beige
+                            ),
+                            publisher: .init(
+                                id: 328,
+                                nickname: "테스트유저3",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 328,
+                                name: "테스트 노래3",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 328,
+                                    name: "테스트 아티스트3",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        
+                        Note(
+                            id: 329,
+                            content: "테스트 내용입니다3.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통",
+                                background: .beige
+                            ),
+                            publisher: .init(
+                                id: 329,
+                                nickname: "테스트유저3",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 329,
+                                name: "테스트 노래3",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 329,
+                                    name: "테스트 아티스트3",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        
                     ]
                 )
                 .setFailureType(to: NoteError.self)

--- a/Projects/Feature/Home/Testing/Sources/MockGetNotesUseCase.swift
+++ b/Projects/Feature/Home/Testing/Sources/MockGetNotesUseCase.swift
@@ -10,7 +10,8 @@ import Foundation
 
 import Domain
 
-public struct MockGetNotesUseCase: GetNotesUseCaseInterface {
+public class MockGetNotesUseCase: GetNotesUseCaseInterface {
+    private var shouldStopPagination: Bool = false
     public init() {}
     
     public func execute(
@@ -18,101 +19,208 @@ public struct MockGetNotesUseCase: GetNotesUseCaseInterface {
         perPage: Int,
         mustHaveLyrics: Bool
     ) -> AnyPublisher<[Note], NoteError> {
-        return Just(
-            [
-                Note(
-                    id: 1,
-                    content: "테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
-                    status: .published,
-                    createdAt: .distantPast,
-                    lyrics: .init(
-                        content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
-                        background: .skyblue
-                    ),
-                    publisher: .init(
+        if isInitial {
+            self.shouldStopPagination = false
+            return Just(
+                [
+                    Note(
                         id: 1,
-                        nickname: "테스트유저1",
-                        profileCharacterType: .poopHair
-                    ),
-                    song: .init(
-                        id: 1,
-                        name: "everything",
-                        imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
-                        artist: .init(
+                        content: "테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                            background: .skyblue
+                        ),
+                        publisher: .init(
                             id: 1,
-                            name: "검정치마",
-                            imageSource: "www.com",
-                            isFavorite: false
-                        )
-                    ),
-                    commentsCount: 0,
-                    likesCount: 0,
-                    isLiked: false,
-                    isBookmarked: false
-                ),
-                Note(
-                    id: 2,
-                    content: "테스트 내용입니다2.",
-                    status: .published,
-                    createdAt: .distantPast,
-                    lyrics: .init(
-                        content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
-                        background: .black
-                    ),
-                    publisher: .init(
-                        id: 1,
-                        nickname: "테스트유저2",
-                        profileCharacterType: .poopHair
-                    ),
-                    song: .init(
-                        id: 1,
-                        name: "테스트 노래2",
-                        imageUrl: "1234.com",
-                        artist: .init(
+                            nickname: "테스트유저1",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
                             id: 1,
-                            name: "테스트 아티스트2",
-                            imageSource: "www.com",
-                            isFavorite: false
+                            name: "everything",
+                            imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                            artist: .init(
+                                id: 1,
+                                name: "검정치마",
+                                imageSource: "",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    ),
+                    Note(
+                        id: 2,
+                        content: "테스트 내용입니다2.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                            background: .black
+                        ),
+                        publisher: .init(
+                            id: 2,
+                            nickname: "테스트유저2",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 2,
+                            name: "테스트 노래2",
+                            imageUrl: "",
+                            artist: .init(
+                                id: 1,
+                                name: "테스트 아티스트2",
+                                imageSource: "",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    ),
+                    Note(
+                        id: 3,
+                        content: "테스트 내용입니다3.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통",
+                            background: .beige
+                        ),
+                        publisher: .init(
+                            id: 3,
+                            nickname: "테스트유저3",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 3,
+                            name: "테스트 노래3",
+                            imageUrl: "",
+                            artist: .init(
+                                id: 1,
+                                name: "테스트 아티스트3",
+                                imageSource: "",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    )
+                ]
+            )
+            .setFailureType(to: NoteError.self)
+            .eraseToAnyPublisher()
+        } else {
+            if !shouldStopPagination {
+                shouldStopPagination = true
+                return Just(
+                    [
+                        Note(
+                            id: 321,
+                            content: "테스트 추가 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                                background: .skyblue
+                            ),
+                            publisher: .init(
+                                id: 321,
+                                nickname: "테스트유저1",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 321,
+                                name: "everything",
+                                imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                                artist: .init(
+                                    id: 321,
+                                    name: "검정치마",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 322,
+                            content: "테스트 내용입니다2.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                                background: .black
+                            ),
+                            publisher: .init(
+                                id: 322,
+                                nickname: "테스트유저2",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 322,
+                                name: "테스트 노래2",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트2",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 323,
+                            content: "테스트 내용입니다3.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통",
+                                background: .beige
+                            ),
+                            publisher: .init(
+                                id: 323,
+                                nickname: "테스트유저3",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 323,
+                                name: "테스트 노래3",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트3",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
                         )
-                    ),
-                    commentsCount: 0,
-                    likesCount: 0,
-                    isLiked: false,
-                    isBookmarked: false
-                ),
-                Note(
-                    id: 3,
-                    content: "테스트 내용입니다3.",
-                    status: .published,
-                    createdAt: .distantPast,
-                    lyrics: .init(
-                        content: "난 너의 아픔 속에 너의 고통",
-                        background: .beige
-                    ),
-                    publisher: .init(
-                        id: 1,
-                        nickname: "테스트유저3",
-                        profileCharacterType: .poopHair
-                    ),
-                    song: .init(
-                        id: 1,
-                        name: "테스트 노래3",
-                        imageUrl: "1234.com",
-                        artist: .init(
-                            id: 1,
-                            name: "테스트 아티스트3",
-                            imageSource: "www.com",
-                            isFavorite: false
-                        )
-                    ),
-                    commentsCount: 0,
-                    likesCount: 0,
-                    isLiked: false,
-                    isBookmarked: false
+                    ]
                 )
-            ]
-        )
-        .setFailureType(to: NoteError.self)
-        .eraseToAnyPublisher()
+                .setFailureType(to: NoteError.self)
+                .eraseToAnyPublisher()
+            } else {
+                return Empty()
+                    .setFailureType(to: NoteError.self)
+                    .eraseToAnyPublisher()
+            }
+        }
     }
 }

--- a/Projects/Feature/Home/Testing/Sources/MockGetSongNotesUseCase.swift
+++ b/Projects/Feature/Home/Testing/Sources/MockGetSongNotesUseCase.swift
@@ -10,7 +10,8 @@ import Foundation
 
 import Domain
 
-public struct MockGetSongNotesUseCase: GetSongNotesUseCaseInterface {
+public class MockGetSongNotesUseCase: GetSongNotesUseCaseInterface {
+    private var shouldStopPagination: Bool = false
     public init() {}
     
     public func execute(
@@ -19,103 +20,209 @@ public struct MockGetSongNotesUseCase: GetSongNotesUseCaseInterface {
         mustHaveLyrics: Bool,
         songID: Int
     ) -> AnyPublisher<[Note], NoteError> {
-        return Just(
-            [
-                Note(
-                    id: 1,
-                    content: "테스트 내용입니다.",
-                    status: .published,
-                    createdAt: .distantPast,
-                    lyrics: .init(
-                        content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
-                        background: .skyblue
-                    ),
-                    publisher: .init(
+        if isInitial {
+            self.shouldStopPagination = false
+            
+            return Just(
+                [
+                    Note(
                         id: 1,
-                        nickname: "테스트유저1",
-                        profileCharacterType: .poopHair
-                    ),
-                    song: .init(
-                        id: 1,
-                        name: "everything",
-                        imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
-                        artist: .init(
+                        content: "테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                            background: .skyblue
+                        ),
+                        publisher: .init(
                             id: 1,
-                            name: "검정치마",
-                            imageSource: "www.com",
-                            isFavorite: false
-                        )
-                    ),
-                    commentsCount: 0,
-                    likesCount: 0,
-                    isLiked: false,
-                    isBookmarked: false
-                ),
-                Note(
-                    id: 2,
-                    content: "테스트 내용입니다2.",
-                    status: .published,
-                    createdAt: .distantPast,
-                    lyrics: .init(
-                        content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
-                        background: .black
-                    ),
-                    publisher: .init(
-                        id: 1,
-                        nickname: "테스트유저2",
-                        profileCharacterType: .poopHair
-                    ),
-                    song: .init(
-                        id: 1,
-                        name: "테스트 노래2",
-                        imageUrl: "1234.com",
-                        artist: .init(
+                            nickname: "테스트유저1",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
                             id: 1,
-                            name: "테스트 아티스트2",
-                            imageSource: "www.com",
-                            isFavorite: false
+                            name: "everything",
+                            imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                            artist: .init(
+                                id: 1,
+                                name: "검정치마",
+                                imageSource: "",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    ),
+                    Note(
+                        id: 2,
+                        content: "테스트 내용입니다2.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                            background: .black
+                        ),
+                        publisher: .init(
+                            id: 2,
+                            nickname: "테스트유저2",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 2,
+                            name: "테스트 노래2",
+                            imageUrl: "",
+                            artist: .init(
+                                id: 1,
+                                name: "테스트 아티스트2",
+                                imageSource: "",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    ),
+                    Note(
+                        id: 3,
+                        content: "테스트 내용입니다3.",
+                        status: .published,
+                        createdAt: .distantPast,
+                        lyrics: .init(
+                            content: "난 너의 아픔 속에 너의 고통",
+                            background: .beige
+                        ),
+                        publisher: .init(
+                            id: 3,
+                            nickname: "테스트유저3",
+                            profileCharacterType: .poopHair
+                        ),
+                        song: .init(
+                            id: 3,
+                            name: "테스트 노래3",
+                            imageUrl: "",
+                            artist: .init(
+                                id: 1,
+                                name: "테스트 아티스트3",
+                                imageSource: "",
+                                isFavorite: false
+                            )
+                        ),
+                        commentsCount: 0,
+                        likesCount: 0,
+                        isLiked: false,
+                        isBookmarked: false
+                    )
+                ]
+            )
+            .setFailureType(to: NoteError.self)
+            .eraseToAnyPublisher()
+        } else {
+            if !shouldStopPagination {
+                shouldStopPagination = true
+                return Just(
+                    [
+                        Note(
+                            id: 321,
+                            content: "테스트 추가 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.테스트 내용입니다.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야",
+                                background: .skyblue
+                            ),
+                            publisher: .init(
+                                id: 321,
+                                nickname: "테스트유저1",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 321,
+                                name: "everything",
+                                imageUrl: "https://i.scdn.co/image/ab67616d0000b2739c3a4e471c5e82a457dce2c0",
+                                artist: .init(
+                                    id: 321,
+                                    name: "검정치마",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 322,
+                            content: "테스트 내용입니다2.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통 속에 기생\n하고 있는 아름다운 벌레야\n 이 밤이 지나고 우린 이상하지 않을까. 우린 어디서부터 잘못된 걸까 알고 싶지만 이제 더 이상 미련도 갖지 않은 내 자신이 이상해",
+                                background: .black
+                            ),
+                            publisher: .init(
+                                id: 322,
+                                nickname: "테스트유저2",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 322,
+                                name: "테스트 노래2",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트2",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
+                        ),
+                        Note(
+                            id: 323,
+                            content: "테스트 내용입니다3.",
+                            status: .published,
+                            createdAt: .distantPast,
+                            lyrics: .init(
+                                content: "난 너의 아픔 속에 너의 고통",
+                                background: .beige
+                            ),
+                            publisher: .init(
+                                id: 323,
+                                nickname: "테스트유저3",
+                                profileCharacterType: .poopHair
+                            ),
+                            song: .init(
+                                id: 323,
+                                name: "테스트 노래3",
+                                imageUrl: "",
+                                artist: .init(
+                                    id: 1,
+                                    name: "테스트 아티스트3",
+                                    imageSource: "",
+                                    isFavorite: false
+                                )
+                            ),
+                            commentsCount: 0,
+                            likesCount: 0,
+                            isLiked: false,
+                            isBookmarked: false
                         )
-                    ),
-                    commentsCount: 0,
-                    likesCount: 0,
-                    isLiked: false,
-                    isBookmarked: false
-                ),
-                Note(
-                    id: 3,
-                    content: "테스트 내용입니다3.",
-                    status: .published,
-                    createdAt: .distantPast,
-                    lyrics: .init(
-                        content: "난 너의 아픔 속에 너의 고통",
-                        background: .beige
-                    ),
-                    publisher: .init(
-                        id: 1,
-                        nickname: "테스트유저3",
-                        profileCharacterType: .poopHair
-                    ),
-                    song: .init(
-                        id: 1,
-                        name: "테스트 노래3",
-                        imageUrl: "1234.com",
-                        artist: .init(
-                            id: 1,
-                            name: "테스트 아티스트3",
-                            imageSource: "www.com",
-                            isFavorite: false
-                        )
-                    ),
-                    commentsCount: 0,
-                    likesCount: 0,
-                    isLiked: false,
-                    isBookmarked: false
+                    ]
                 )
-            ]
-        )
-        .setFailureType(to: NoteError.self)
-        .eraseToAnyPublisher()
+                .setFailureType(to: NoteError.self)
+                .eraseToAnyPublisher()
+            } else {
+                return Empty()
+                    .setFailureType(to: NoteError.self)
+                    .eraseToAnyPublisher()
+            }
+        }
     }
-    
-    
 }


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [x] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경
- 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면의 Cell내부의 버튼을 탭 할 경우 엉뚱한 cell의 상태가 변경되는 버그를 수정해야 합니다.
- 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면에서 pull-to-refresh를 할 경우 cell이 상하로 튀는 버그를 수정해야 합니다.

## 목표

- 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면의 Cell내부의 버튼을 탭 할 경우 엉뚱한 cell의 상태가 변경되는 버그 수정
- 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면에서 pull-to-refresh를 할 경우 cell이 상하로 튀는 버그를 수정

## 결과 (Optional)
|홈화면|노트상세화면|노트댓글화면|커뮤니티 메인 화면|
|--|--|--|--|
|<img src="https://github.com/user-attachments/assets/1d0b1bed-0a68-4205-9d6d-e7fd8c0a2750" width="250">|<img src="https://github.com/user-attachments/assets/d98bade3-ac44-4e4f-9908-abae9df7b3e0" width="250">|<img src="https://github.com/user-attachments/assets/281faf8a-87b6-4383-8d7d-a9528086b4f7" width="250">|<img src="https://github.com/user-attachments/assets/9ce037de-5a50-4da3-89cb-813d48e260d2" width="250">|

### 내가 작성한 댓글의 배경색이 화면 가로 범위를 꽉 채우도록 추가 수정
<img src="https://github.com/user-attachments/assets/2473e237-fbe9-47b0-b0de-2a528fd9019b" width="250">

- [x] 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면의 Cell내부의 버튼을 탭 할 경우 엉뚱한 cell의 상태가 변경되는 버그 수정
- [x] 홈화면, 노트상세화면, 노트댓글화면 그리고 커뮤니티 메인 화면에서 pull-to-refresh를 할 경우 cell이 상하로 튀는 버그를 수정
- [x] 댓글 내용이 화면에 보이지 않던 버그 수정
- [x] 사용된 헤더(UICollectionReusableView)들 내부의 버튼 바인딩이 중복으로 발생하는 문제 해결
## Trouble or Trouble Shooting(Optional)

<!-- 해당 PR에서 발생한 문제를 해결한 내용을 작성해주세요.  !-->
pull-to-refresh시 cell을 단순히`apply(snapshot)`메서드를 활용하여 업데이트 할 경우 cell이 상하로 튀는 문제가 있었습니다.

해당 문제는 `communityMainDataSource.applySnapshotUsingReloadData(snapshot)`메서드로 해결할 수 있었지만 해당 메서드만을 사용하여 cell을 업데이트할 경우 cell이 추가되거나 삭제될 때 animation을 줄 수 없다는 단점이 있습니다.

해당 딜레마를 해결하기 위해 아래와 같은 로직을 활용하여 문제를 해결하였습니다.
refreshControl의 isRefreshing상태를 판단하여 true일 경우에는 reloadData를 아닌 경우에는 item 갯수가 변경 될 때만 animation을 주도록 로직을 주어서 reloadData사용을 최적화 하였습니다. 뿐만 아니라 단순 cell 내부의 ui 변경일 경우에는 animation을 주지 않도록 로직을 개선할 수 있었습니다.
``` swift
        // 노트 섹션 업데이트
        if snapshot.sectionIdentifiers.contains(.notes) {
            let currentItems = snapshot.itemIdentifiers(inSection: .notes)
            
            if newItems.isEmpty {
                snapshot.deleteItems(currentItems)
                snapshot.appendItems([.emptyNote], toSection: .notes)
            } else {
                snapshot.deleteItems(currentItems)
                snapshot.appendItems(newItems, toSection: .notes)
            }
            
            let isCountDifferent = currentItems.count != newItems.count
            
            guard let refreshControl = self.communityMainCollectionView.refreshControl else {
                // pull-to-refresh가 없는 경우 apply snapshot만 적용. 갯수가 달라질때만 animation
                communityMainDataSource.apply(
                    snapshot,
                    animatingDifferences: isCountDifferent
                )
                return
            }
            // pull-to-refresh 중일 경우 reloadData를 활용하여 apply snapshot에 의해서 생기는 bounce 방지
            if refreshControl.isRefreshing {
                communityMainDataSource.applySnapshotUsingReloadData(snapshot)
            } else {
                // 그 외의 경우 apply snapshot 활용. 기존 데이터와 신규 데이터의 갯수가 달라질 때만 animation
                communityMainDataSource.apply(
                    snapshot,
                    animatingDifferences: isCountDifferent
                )
            }
        }
```
