### PR TITLE
Fix 회원가입 API, 유저 정보 수정 API, 신고하기 뷰 수정

### DIFF
--- a/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
+++ b/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
@@ -212,21 +212,10 @@ extension FeelinAPI: HTTPNetworking {
         case .reportNote(let request):
             return request
 
+        // 프로필 수정API - 수정하지 않는 항목에 대해서는 아예 비워줘야 에러 발생안함
+        // 모든 값을 같이 보내면 안된다.
         case .patchUserProfile(let request):
-            if let gender = request.gender?.rawValue,
-               let birthYear = request.birthYear {
-                return [
-                    "nickname": request.nickname,
-                    "profileCharacter": request.profileCharacter,
-                    "gender": gender,
-                    "birthYear": "\(birthYear)"
-                ]
-            }
-
-            return [
-                "nickname": request.nickname,
-                "profileCharacter": request.profileCharacter
-            ]
+            return request
 
         case .patchNote(_, let request):
             return request

--- a/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
+++ b/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
@@ -199,6 +199,7 @@ extension FeelinAPI: HTTPNetworking {
                 "artistIds": ids
             ]
 
+        // 건너뛰어서 출생연도, 성별이 없는 경우 encoding 되지 않음
         case .signUp(let request):
             return request
 

--- a/Projects/Core/Network/Interface/Sources/DTO/Request/UserProfileRequest.swift
+++ b/Projects/Core/Network/Interface/Sources/DTO/Request/UserProfileRequest.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 public struct UserProfileRequest: Encodable {
-    public let nickname: String
-    public let profileCharacter: String
+    public let nickname: String?
+    public let profileCharacter: String?
     public var gender: Gender?
     public var birthYear: Int?
 
     public init(
-        nickname: String,
-        profileCharacter: String,
-        gender: Gender?,
-        birthYear: Int?
+        nickname: String? = nil,
+        profileCharacter: String? = nil,
+        gender: Gender? = nil,
+        birthYear: Int? = nil
     ) {
         self.nickname = nickname
         self.profileCharacter = profileCharacter

--- a/Projects/Core/Network/Interface/Sources/DTO/Request/UserSignUpRequest.swift
+++ b/Projects/Core/Network/Interface/Sources/DTO/Request/UserSignUpRequest.swift
@@ -24,8 +24,8 @@ public struct UserSignUpRequest: Encodable {
         authProvider: String,
         nickname: String,
         profileCharacter: String,
-        gender: String?,
-        birthYear: String?,
+        gender: String? = nil,
+        birthYear: String? = nil,
         terms: [Term],
         isAdmin: Bool
     ) {

--- a/Projects/Core/Network/Interface/Sources/DTO/Response/UserProfileResponse.swift
+++ b/Projects/Core/Network/Interface/Sources/DTO/Response/UserProfileResponse.swift
@@ -13,7 +13,7 @@ public struct UserProfileResponse: Decodable {
     public let profileCharacterType: String
     public let gender: String?
     public let birthYear: Int?
-    public let feedbackID: String?
+    public let feedbackID: String
     public let authProvider: String
 
     public init(
@@ -22,7 +22,7 @@ public struct UserProfileResponse: Decodable {
         profileCharacterType: String,
         gender: String?,
         birthYear: Int?,
-        feedbackID: String?,
+        feedbackID: String,
         authProvider: String
     ) {
         self.id = id

--- a/Projects/Domain/OAuth/Interface/Sources/Model/UserSignUpEntity.swift
+++ b/Projects/Domain/OAuth/Interface/Sources/Model/UserSignUpEntity.swift
@@ -40,14 +40,14 @@ public struct UserSignUpEntity {
     public func toDTO() -> UserSignUpRequest {
         let oAuthType = oAuthType ?? .apple
         let authProvider = OAuthProvider(rawValue: oAuthType.rawValue) ?? .apple
-
+        
         return UserSignUpRequest(
             socialAccessToken: socialAccessToken ?? "",
             authProvider: authProvider.rawValue,
             nickname: nickname ?? "",
             profileCharacter: profileCharacter ?? "",
-            gender: gender?.toDTO.rawValue ?? "",
-            birthYear: birthYear ?? "",
+            gender: gender?.toDTO.rawValue,
+            birthYear: birthYear,
             terms: terms,
             isAdmin: isAdmin
         )

--- a/Projects/Domain/UserProfile/Interface/Sources/Models/UserProfile.swift
+++ b/Projects/Domain/UserProfile/Interface/Sources/Models/UserProfile.swift
@@ -17,7 +17,7 @@ public struct UserProfile {
     public let profileCharacterType: ProfileCharacterType
     public var gender: GenderEntity?
     public var birthYear: Int?
-    public let feedbackID: String?
+    public let feedbackID: String
     public let authProvider: String
 
     public init(
@@ -26,7 +26,7 @@ public struct UserProfile {
         profileCharacterType: ProfileCharacterType,
         gender: GenderEntity?,
         birthYear: Int?,
-        feedbackID: String?,
+        feedbackID: String,
         authProvider: String
     ) {
         self.id = id

--- a/Projects/Domain/UserProfile/Interface/Sources/Models/UserProfileRequestValue.swift
+++ b/Projects/Domain/UserProfile/Interface/Sources/Models/UserProfileRequestValue.swift
@@ -12,16 +12,16 @@ import Foundation
 import DomainOAuthInterface
 
 public struct UserProfileRequestValue {
-    public let nickname: String
-    public let profileCharacter: ProfileCharacterType
+    public let nickname: String?
+    public let profileCharacter: ProfileCharacterType?
     public var gender: GenderEntity?
     public var birthYear: Int?
 
     public init(
-        nickname: String,
-        profileCharacter: ProfileCharacterType,
-        gender: GenderEntity?,
-        birthYear: Int?
+        nickname: String? = nil,
+        profileCharacter: ProfileCharacterType? = nil,
+        gender: GenderEntity? = nil,
+        birthYear: Int? = nil
     ) {
         self.nickname = nickname
         self.profileCharacter = profileCharacter
@@ -32,7 +32,7 @@ public struct UserProfileRequestValue {
     public func toDTO() -> UserProfileRequest {
         return UserProfileRequest(
             nickname: nickname,
-            profileCharacter: profileCharacter.rawValue,
+            profileCharacter: profileCharacter?.rawValue,
             gender: gender?.toDTO,
             birthYear: birthYear
         )

--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/ReportViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/ReportViewController.swift
@@ -113,20 +113,8 @@ public final class ReportViewController: UIViewController {
 
         CombineKeyboard.keyboardHeightPublisher
             .sink { [weak self] keyboardHeight in
-                self?.rootScrollView.contentInset.bottom = keyboardHeight
-                self?.rootScrollView.verticalScrollIndicatorInsets.bottom = keyboardHeight
-
-                // 스크롤 위치 조정을 위해 caretRect를 사용
-                guard let textView = self?.selectedReportReasonView?.reasonTextView,
-                      let end = textView.selectedTextRange?.end else { return }
-                let caretRect = textView.caretRect(for: end)
-
-                // caret 위치로 스크롤 조정
-                self?.rootScrollView.scrollRectToVisible(caretRect, animated: true)
-
-                UIView.animate(withDuration: 0.3) {
-                    self?.view.layoutIfNeeded()
-                }
+                self?.rootScrollView.contentInset.bottom = keyboardHeight * 0.4
+                self?.rootScrollView.verticalScrollIndicatorInsets.bottom = keyboardHeight * 0.4
             }
             .store(in: &cancellables)
     }
@@ -157,7 +145,8 @@ public final class ReportViewController: UIViewController {
             view.endEditing(true)
         }
 
-        reportView.contentView.flex.layout(mode: .adjustHeight)
+        contentView.flex.markDirty()
+        rootScrollView.flex.layout(mode: .adjustHeight)
     }
 
     private func scrollToTextView(textView: UITextView?) {
@@ -178,9 +167,8 @@ public final class ReportViewController: UIViewController {
         reasonTextView.textPublisher(for: [.didChange, .didBeginEditing])
             .receive(on: DispatchQueue.main)
             .sink { [weak self] text in
-                self?.adjustTextViewHeight(reasonTextView)
-
                 guard text != "", text != Const.reasonPlaceholder else { return }
+                self?.adjustTextViewHeight(reasonTextView)
                 self?.reportReasonDescriptionPublisher.send(text)
             }
             .store(in: &cancellables)
@@ -209,14 +197,12 @@ public final class ReportViewController: UIViewController {
             textView.isScrollEnabled = true
         }
 
-        reportView.reportReasonView.flex.layout()
-        contentView.flex.layout(mode: .adjustHeight)
-
-        // rootScrollView의 contentSize를 업데이트
-        rootScrollView.contentSize = contentView.frame.size
-
         // 스크롤 위치 조정을 위해 caretRect를 사용
         scrollToTextView(textView: textView)
+
+        rootScrollView.flex.layout()
+        // rootScrollView의 contentSize를 업데이트
+        rootScrollView.contentSize = contentView.frame.size
     }
 }
 

--- a/Projects/Feature/MyPage/Interface/Sources/ViewControllers/EditUserInfoViewController.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewControllers/EditUserInfoViewController.swift
@@ -49,7 +49,7 @@ public final class EditUserInfoViewController: UIViewController {
         overrideUserInterfaceStyle = .light
         bind()
         genderCollectionView.dataSource = self
-        configure(model: viewModel.model)
+        configure(model: viewModel.userProfile)
     }
 
     private func bind() {
@@ -157,7 +157,7 @@ extension EditUserInfoViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: GenderCell.self)
         cell.configure(with: GenderEntity.allCases[indexPath.row])
 
-        if let gender = viewModel.model.gender,
+        if let gender = viewModel.userProfile.gender,
            indexPath.row == gender.index {
             cell.setSelected(true)
             collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])

--- a/Projects/Feature/MyPage/Interface/Sources/ViewModels/EditUserInfoViewModel.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewModels/EditUserInfoViewModel.swift
@@ -29,14 +29,14 @@ public final class EditUserInfoViewModel {
     private let patchUserProfileUseCase: PatchUserProfileUseCaseInterface
 
     private var cancellables: Set<AnyCancellable> = .init()
-    public let model: UserProfile
+    public let userProfile: UserProfile
 
     public init(
         patchUserProfileUseCase: PatchUserProfileUseCaseInterface,
         model: UserProfile
     ) {
         self.patchUserProfileUseCase = patchUserProfileUseCase
-        self.model = model
+        self.userProfile = model
     }
 
     func transform(_ input: Input) -> Output {
@@ -52,7 +52,7 @@ public final class EditUserInfoViewModel {
     func checkSaveButtonIsEnabled(input: Input) -> AnyPublisher<Bool, Never> {
         return input.birthYearPublisher
             .map { [weak self] birthYear in
-                return self?.model.birthYear != birthYear
+                return self?.userProfile.birthYear != birthYear
             }
             .eraseToAnyPublisher()
     }
@@ -63,12 +63,12 @@ public final class EditUserInfoViewModel {
                 input.genderPublisher,
                 input.birthYearPublisher
             )
-            .map { (gender, birthYear) -> UserProfileRequestValue in
+            .map { [weak self] (gender, birthYear) -> UserProfileRequestValue in
+                let gender = GenderEntity(rawValue: gender)
+
                 return UserProfileRequestValue(
-                    nickname: self.model.nickname,
-                    profileCharacter: self.model.profileCharacterType,
-                    gender: GenderEntity(rawValue: gender),
-                    birthYear: birthYear
+                    gender: gender != self?.userProfile.gender ? gender : nil,
+                    birthYear: birthYear != self?.userProfile.birthYear ? birthYear : nil
                 )
             }
             .eraseToAnyPublisher()

--- a/Projects/Feature/MyPage/Interface/Sources/ViewModels/ProfileEditViewModel.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewModels/ProfileEditViewModel.swift
@@ -81,18 +81,17 @@ private extension ProfileEditViewModel {
             .compactMap { $0 }
             .eraseToAnyPublisher()
 
+        // 데이터 변경이 없는 경우, 기존 데이터를 보내면 API 에러가 발생함
         let combinedUserProfileModelPublisher = Publishers
             .CombineLatest(
                 validNicknamePublisher,
                 input.profileImagePublisher
             )
-            .map { (nickname, profileCharacter) -> UserProfileRequestValue in
+            .map { [weak self] (nickname, profileCharacter) -> UserProfileRequestValue in
                 let type = ProfileCharacterType(rawValue: profileCharacter) ?? .braidedHair
                 return UserProfileRequestValue(
-                    nickname: nickname,
-                    profileCharacter: type,
-                    gender: self.userProfile.gender,
-                    birthYear: self.userProfile.birthYear
+                    nickname: nickname != self?.userProfile.nickname ? nickname : nil,
+                    profileCharacter: type != self?.userProfile.profileCharacterType ? type : nil
                 )
             }
             .eraseToAnyPublisher()


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [x] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경

<!-- 해당 PR에서 개발한 내용에 대해 알아야 하는 배경지식을 작성해주세요. -->

- 회원가입 API 에러

>  성별, 출생연도를 제외하고 가입 시 에러가 발생했습니다. 이유는 해당 값이 없는 경우 ""(빈 문자열)로 보내고 있었는데, 빈문자열에 대한 처리가 되어 있지 않아서 발생한 문제입니다. 이 문제를 수정하기 어려워 프론트에서 빈 문자열일 경우, request value로 넣지 않는 방식으로 변경했습니다.

- 유저 정보 API 에러

 **유저 정보 불러오기**

> 회원가입에서 성별, 출생연도를 건너뛴 경우, 마이페이지에서 유저정보를 불러올 수 없는 문제가 있었지만, API 수정으로 해결했습니다.

  - 유저 정보 수정

> 유저 정보를 수정할 때, 변경된 데이터만 Request value로 보내야 합니다. 그렇지 않으면 에러를 발생시켜 수정했습니다.

**신고하기 노트**

- 신고사유 선택 시 신고 사유 뷰의 width가 줄어드는 문제가 있었습니다. 엉뚱한 뷰의 layout 업데이트를 하고 있었습니다. 
- 키보드가 올라간 경우, 스크롤이 제대로 되지 않는 문제가 있었습니다. 

## 목표

<!-- 해당 PR에서 개발/수정 한 기능의 목표를 작성해주세요. -->

- [x] 회원가입 기능 정상작동
- [x] 유저 정보 수정 기능 정상작동
- [x] 신고하기 UI 버그 수정
