### PR TITLE
QA-0.01(4) 노트 작성 / 수정, 마이페이지, 회원 설정 수정

### DIFF
--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/WritingNote/EditNoteViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/WritingNote/EditNoteViewController.swift
@@ -55,6 +55,7 @@ public final class EditNoteViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
+        editNoteView.naviTitleLabel.text = "노트 수정"
         bind()
         setUpTextView()
         configure(viewModel.note)

--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/WritingNote/PostNoteViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/WritingNote/PostNoteViewController.swift
@@ -57,6 +57,7 @@ public final class PostNoteViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
+        postNoteView.naviTitleLabel.text = "노트 작성"
         bind()
         setUpTextView()
     }

--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/WritingNote/SearchSongViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/WritingNote/SearchSongViewController.swift
@@ -16,7 +16,7 @@ public protocol SearchSongViewControllerDelegate: AnyObject {
     func popRootViewController()
 }
 
-public final class SearchSongViewController: UIViewController {
+public final class SearchSongViewController: UIViewController, NoteMusicHandling {
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -163,7 +163,17 @@ extension SearchSongViewController: UICollectionViewDataSource {
     ) -> UICollectionViewCell {
 
         let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: SongCollectionViewCell.self)
-        cell.configure(model: viewModel.fetchedSongs[indexPath.row])
+        let model = viewModel.fetchedSongs[indexPath.row]
+        cell.configure(model: model)
+
+        cell.playButton.tapPublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                print(model.artist.name)
+                print(model.name)
+                openYouTube(query: "\(model.artist.name) \(model.name)")
+            }
+            .store(in: &cell.cancellables)
 
         return cell
     }

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/EditNoteViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/EditNoteViewModel.swift
@@ -13,6 +13,11 @@ import Core
 
 public final class EditNoteViewModel {
     typealias EditNoteResult = Result<FeelinSuccessResponse, NoteError>
+    
+    private enum Const {
+        static let lyricsPlaceholder = "좋아하는 가사를 적어주세요 (선택)"
+        static let notePlaceholder = "생각을 남겨보세요."
+    }
 
     struct Input {
         let lyricsTextViewTypePublisher: AnyPublisher<String, Never>
@@ -57,12 +62,12 @@ private extension EditNoteViewModel {
     func isEnabledCompleteButton(_ input: Input) -> AnyPublisher<Bool, Never> {
         let hasWrittenNotePublisher = input.noteTextViewTypePublisher
             .map { noteContent in
-                return self.note.content != noteContent
+                return self.note.content != noteContent && noteContent != Const.notePlaceholder
             }
 
         let hasWrittenLyricsNotePublisher = input.lyricsTextViewTypePublisher
             .map { lyricsContent in
-                return self.note.lyrics?.content != lyricsContent
+                return self.note.lyrics?.content != lyricsContent && lyricsContent != Const.lyricsPlaceholder
             }
 
         let hasSelectedLyricsBackgroundPublisher = input.lyricsBackgroundSelectPublisher
@@ -83,9 +88,9 @@ private extension EditNoteViewModel {
     }
 
     func isEnabledCompleteButton(lyricsContent: String, background: LyricsBackground?, noteContent: String) -> Bool {
-        return self.note.lyrics?.content != lyricsContent 
+        return (self.note.lyrics?.content != lyricsContent && lyricsContent != Const.lyricsPlaceholder)
         || self.note.lyrics?.background != background
-        || self.note.content != noteContent
+        || (self.note.content != noteContent && noteContent != Const.notePlaceholder)
     }
 
     func isSelectLyricsBackground(_ input: Input) -> AnyPublisher<LyricsBackground?, Never> {
@@ -99,7 +104,7 @@ private extension EditNoteViewModel {
     func checkLyricsText(_ input: Input) -> AnyPublisher<Bool, Never> {
         return input.lyricsTextViewTypePublisher
             .map { text in
-                return text.isEmpty == false && text != "좋아하는 가사를 적어주세요 (선택)"
+                return text.isEmpty == false && text != Const.lyricsPlaceholder
             }
             .eraseToAnyPublisher()
     }
@@ -116,7 +121,7 @@ private extension EditNoteViewModel {
             }
             .map { (lyrics, background, noteContent) in
                 PatchNoteValue(
-                    lyrics: lyrics != "좋아하는 가사를 적어주세요 (선택)" ? lyrics : nil,
+                    lyrics: lyrics != Const.lyricsPlaceholder ? lyrics : nil,
                     background: background,
                     content: noteContent,
                     status: self.note.status

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/EditNoteViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/EditNoteViewModel.swift
@@ -131,6 +131,7 @@ private extension EditNoteViewModel {
 
         return input.completeButtonTapPublisher
             .combineLatest(validNotePublisher)
+            .throttle(for: .seconds(2), scheduler: RunLoop.main, latest: false)
             .flatMap { [weak self] (_, value) -> AnyPublisher<EditNoteResult, Never> in
                 guard let self = self else {
                     return Empty().eraseToAnyPublisher()

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/PostNoteViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/PostNoteViewModel.swift
@@ -14,6 +14,11 @@ import Core
 public final class PostNoteViewModel {
     typealias PostNoteResult = Result<FeelinSuccessResponse, NoteError>
 
+    private enum Const {
+        static let lyricsPlaceholder = "좋아하는 가사를 적어주세요 (선택)"
+        static let notePlaceholder = "생각을 남겨보세요."
+    }
+
     struct Input {
         let songTapPublisher: AnyPublisher<Song, Never>
         let lyricsTextViewTypePublisher: AnyPublisher<String?, Never>
@@ -63,7 +68,7 @@ private extension PostNoteViewModel {
             input.postNoteStatusPublisher
         )
         .map { song, noteContent, status in
-            return !noteContent.isEmpty && status == .draft
+            return !noteContent.isEmpty && noteContent != Const.notePlaceholder && status == .draft
         }
         .eraseToAnyPublisher()
     }
@@ -87,7 +92,7 @@ private extension PostNoteViewModel {
     func checkLyricsText(_ input: Input) -> AnyPublisher<Bool, Never> {
         return input.lyricsTextViewTypePublisher
             .map { text in
-                return text?.isEmpty == false && text != "좋아하는 가사를 적어주세요 (선택)"
+                return text?.isEmpty == false && text != Const.lyricsPlaceholder
             }
             .eraseToAnyPublisher()
     }
@@ -99,6 +104,9 @@ private extension PostNoteViewModel {
                 input.noteTextViewTypePublisher,
                 input.postNoteStatusPublisher
             )
+            .filter({ (song, noteContent, status) in
+                return !noteContent.isEmpty && noteContent != Const.notePlaceholder
+            })
             .eraseToAnyPublisher()
 
         let optionalFieldsPublisher = Publishers
@@ -120,7 +128,7 @@ private extension PostNoteViewModel {
 
                 return PostNoteValue(
                     id: song.id,
-                    lyrics: lyrics != "좋아하는 가사를 적어주세요 (선택)" ? lyrics : nil,
+                    lyrics: lyrics != Const.lyricsPlaceholder ? lyrics : nil,
                     background: lyricsBackground,
                     content: noteContent,
                     status: status

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/PostNoteViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/PostNoteViewModel.swift
@@ -138,6 +138,7 @@ private extension PostNoteViewModel {
 
         return input.completeButtonTapPublisher
               .combineLatest(combinedPublisher)
+              .throttle(for: .seconds(2), scheduler: RunLoop.main, latest: false)
               .flatMap { [weak self] (_, value) -> AnyPublisher<PostNoteResult, Never> in
                   guard let self = self else {
                       return Empty().eraseToAnyPublisher()

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/SongCollectionViewCell.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/SongCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 import Domain
 import FlexLayout
@@ -51,6 +52,8 @@ final class SongCollectionViewCell: UICollectionViewCell, Reusable {
         button.setImage(FeelinImages.play, for: .normal)
         return button
     }()
+
+    var cancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 

--- a/Projects/Feature/Home/Interface/Sources/Views/WritingNote/WritingNoteView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/WritingNote/WritingNoteView.swift
@@ -28,7 +28,7 @@ public final class WritingNoteView: UIView {
         return button
     }()
 
-    private let naviTitleLabel: UILabel = {
+    let naviTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "노트 작성"
         label.font = SharedDesignSystemFontFamily.Pretendard.bold.font(size: 18)

--- a/Projects/Feature/MyPage/Interface/Sources/ViewControllers/PageControl/MyPageTabViewController.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewControllers/PageControl/MyPageTabViewController.swift
@@ -58,6 +58,7 @@ public final class MyPageTabViewController: ButtonBarPagerTabStripViewController
     }
 
     private func setUpDefault() {
+        settings.style.defaultBarBackgroundColor = Colors.gray01
         settings.style.selectedBarHeight = 2.0
         settings.style.buttonBarMinimumLineSpacing = 0
         settings.style.buttonBarItemFont = SharedDesignSystemFontFamily.Pretendard.semiBold.font(size: 16)

--- a/Projects/Feature/MyPage/Interface/Sources/ViewControllers/SettingViewController.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewControllers/SettingViewController.swift
@@ -51,7 +51,7 @@ public final class SettingViewController: UIViewController {
 
     public init(viewModel: SettingViewModel) {
         self.viewModel = viewModel
-        
+
         super.init(nibName: nil, bundle: .main)
     }
 
@@ -81,21 +81,21 @@ public final class SettingViewController: UIViewController {
         logoutButton.isHidden = userInfo == nil
         deleteUserButton.isHidden = userInfo == nil
     }
-    
+
     private func bindUI() {
         self.viewModel.$logoutResult
             .sink { [weak self] logoutResult in
                 switch logoutResult {
                 case .success:
                     self?.coordinator?.didFinish()
-                    
+
                 case .failure(let error):
                     self?.showAlert(
                         title: error.errorDescription,
                         message: nil,
                         singleActionTitle: "확인"
                     )
-                    
+
                 default:
                     break
                 }
@@ -226,9 +226,10 @@ extension SettingViewController: UITableViewDelegate {
             }
 
         case .serviceUsage,
-                .personalInfo,
-                .serviceInquiry:
+                .personalInfo:
             coordinator?.presentInternalWebViewController(url: item.url)
+        case .serviceInquiry:
+            openWebBrowser(urlStr: item.url)
         }
     }
 }

--- a/Projects/Feature/MyPage/Interface/Sources/ViewModels/ProfileEditViewModel.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewModels/ProfileEditViewModel.swift
@@ -55,7 +55,14 @@ public final class ProfileEditViewModel {
 private extension ProfileEditViewModel {
     func isEnabledSaveButton(_ nickname: String?, _ profileCharacter: String) -> Bool {
         let count = nickname?.count ?? 0
-        return nickname?.isEmpty == false && count < 10 || !profileCharacter.isEmpty
+
+        if let nickname = nickname {
+            return nickname.isEmpty == false && count <= 10 && userProfile.nickname != nickname && nickname.containsOnlyAllowedCharacters == true
+        } else if !profileCharacter.isEmpty {
+            return !profileCharacter.isEmpty && profileCharacter != userProfile.profileCharacterType.rawValue
+        }
+
+        return false
     }
 
     func isEnabledSaveButton(input: Input) -> AnyPublisher<Bool, Never> {
@@ -103,6 +110,7 @@ private extension ProfileEditViewModel {
                 guard let self = self else {
                     return Empty().eraseToAnyPublisher()
                 }
+
                 return self.patchUserInfo(value)
             }
             .eraseToAnyPublisher()

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewModel/ProfileViewModel.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewModel/ProfileViewModel.swift
@@ -46,7 +46,7 @@ public final class ProfileViewModel {
 private extension ProfileViewModel {
     func isEnabledNextButton(_ nickname: String?) -> Bool {
         let count = nickname?.count ?? 0
-        return nickname?.isEmpty == false && count < 10
+        return nickname?.isEmpty == false && count <= 10 && nickname?.containsOnlyAllowedCharacters == true
     }
 
     func checkNextButtonIsEnabled(input: Input) -> AnyPublisher<Bool, Never> {


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [x] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경

<!-- 해당 PR에서 개발한 내용에 대해 알아야 하는 배경지식을 작성해주세요. -->

- 곡 검색 리스트 아이템의 재생 버튼을 클릭 시 유튜브로 연결되지 않는 문제
- 노트 작성 / 수정에서 완료 버튼 상태 변경이 PlaceHolder에서도 되는 문제
- 노트 작성 / 수정 네비게이션 타이틀이 노트작성으로 되어있는 문제
- 서비스 문의하기는 내부 웹뷰가 아니라 사파리 웹으로 연결되야 하는 부분
- 프로필 입력, 수정에서 닉네임 텍스트 검사를 정규식을 통해 진행하지 않고 있는 문제
- 노트 작성 / 수정에서 완료 버튼 여러 번 클릭 할 수 있는 문제
- 마이페이지 페이지 탭 바의 default 컬러가 없는 부분

## 목표

<!-- 해당 PR에서 개발/수정 한 기능의 목표를 작성해주세요. -->

- 곡 검색 리스트 셀 재생 버튼 클릭 시 유튜브로 연결
- 노트 작성 / 수정 완료 버튼 상태 변경 분기 추가
- 노트 작성 / 수정 네비 타이틀 변경
- 회원 설정 페이지 > 서비스 문의하기 사파리 웹으로 연결하도록 수정
- 프로필 입력 / 수정 부분 nickname 텍스트 유효성 검사 분기 추가
- 완료 버튼 여러 번 클릭 되지 않도록 수정
- 마이페이지 탭 바 default color 설정

## 결과 (Optional)

<!-- 개발한 내용의 결과를 설명해주세요. !-->

| 마이페이지 페이징 탭바| 프로필 수정|
|--|--|
|<img src="https://github.com/user-attachments/assets/3a73ee0e-f19a-4102-8aba-324bdc52b154" width="250">|<img src="https://github.com/user-attachments/assets/58a2dc9e-fa7c-4287-81d9-550ef0b85d10" width="250">|
