### PR TITLE
QA-1.0.1 레이아웃 깨지는 부분 수정, Safe Area Bottom 설정 변경, 프로필 수정 페이지 수정

### DIFF
--- a/Projects/App/Sources/Application/AppCoordinator.swift
+++ b/Projects/App/Sources/Application/AppCoordinator.swift
@@ -31,11 +31,13 @@ final class AppCoordinator: Coordinator {
     }
 
     func start() {
-        let viewModel = splashDependencies()
-        let viewController = SplashViewController(viewModel: viewModel)
-        viewController.coordinator = self
-        navigationController.setNavigationBarHidden(true, animated: false)
-        navigationController.pushViewController(viewController, animated: false)
+        let splashCoordinator = SplashCoordinator(
+            navigationController: navigationController
+        )
+
+        splashCoordinator.delegate = self
+        splashCoordinator.start()
+        childCoordinators.append(splashCoordinator)
     }
 }
 

--- a/Projects/App/Sources/Application/Splash/SplashCoordinator.swift
+++ b/Projects/App/Sources/Application/Splash/SplashCoordinator.swift
@@ -1,0 +1,73 @@
+//
+//  SplashCoordinator.swift
+//  Feelin
+//
+//  Created by Derrick kim on 12/16/24.
+//
+
+import UIKit
+import CoordinatorAppInterface
+import CoordinatorTabBarInterface
+import DependencyInjection
+import DomainOAuthInterface
+
+public final class SplashCoordinator: Coordinator {
+    public var appErrorHandler: AppErrorHandlerInterface
+
+    public weak var delegate: CoordinatorDelegate?
+    public var navigationController: UINavigationController
+    public var childCoordinators: [Coordinator]
+
+    public init(
+        navigationController: UINavigationController,
+        appErrorHandler: AppErrorHandlerInterface = AppErrorHandler()
+    ) {
+        self.navigationController = navigationController
+        self.appErrorHandler = appErrorHandler
+        self.childCoordinators = []
+    }
+
+    public func start() {
+        let viewModel = splashDependencies()
+        let viewController = SplashViewController(viewModel: viewModel)
+        viewController.coordinator = self
+        navigationController.setNavigationBarHidden(true, animated: false)
+        navigationController.pushViewController(viewController, animated: false)
+    }
+}
+
+private extension SplashCoordinator {
+    func registerDependencies() {
+        DIContainer.registerNetworkProvider(hasTokenStorage: true)
+        DIContainer.registerUserValidityService()
+    }
+
+    func splashDependencies() -> SplashViewModel {
+        @Injected(.userValidityService) var userValidityService
+
+        let autoLoginUseCase = AutoLoginUseCase(userValidityService: userValidityService)
+        let viewModel = SplashViewModel(autoLoginUseCase: autoLoginUseCase)
+        return viewModel
+    }
+}
+
+extension SplashCoordinator: CoordinatorDelegate, SplashViewControllerDelegate {
+    public func didFinish(childCoordinator: Coordinator) {
+        didFinish()
+    }
+    
+    func connectTabBarFlow() {
+        navigationController.popToRootViewController(animated: false)
+        let onboardingCoordinator = TabBarCoordinator(
+            navigationController: navigationController
+        )
+
+        onboardingCoordinator.delegate = self
+        onboardingCoordinator.start()
+        childCoordinators.append(onboardingCoordinator)
+    }
+    
+    func didFinish() {
+        didFinish(childCoordinator: self)
+    }
+}

--- a/Projects/Coordinator/App/Interface/Sources/Root/CoordinatorInterface.swift
+++ b/Projects/Coordinator/App/Interface/Sources/Root/CoordinatorInterface.swift
@@ -57,8 +57,9 @@ public extension Coordinator {
                     title: errorMessage,
                     message: "에러코드(\(errorCode))",
                     singleActionTitle: "확인") { [weak self] in
-                        self?.appErrorHandler.deleteUserData()
-                        self?.finish()
+                        guard let self = self else { return }
+                        appErrorHandler.deleteUserData()
+                        delegate?.didFinish(childCoordinator: self)
                     }
                 
             case FeelinAPIError.ErrorType.updateRequired.errorCode:

--- a/Projects/Feature/Home/Interface/Sources/Views/ArtistSelectView.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/ArtistSelectView.swift
@@ -126,7 +126,7 @@ final class ArtistSelectView: UIView {
     }
     
     private func setUpArtistCollectionViewLayout() {
-        let totalHorizontalSpacing = flowLayout.minimumInteritemSpacing * 2 + 27 * 2
+        let totalHorizontalSpacing = (flowLayout.minimumInteritemSpacing * 2) + (28 * 2)
         let cellWidth: CGFloat = (self.frame.width - totalHorizontalSpacing) / 3
         let cellHeight: CGFloat = 146
         

--- a/Projects/Feature/MyPage/Interface/Sources/ViewControllers/ProfileEditViewController.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewControllers/ProfileEditViewController.swift
@@ -122,6 +122,7 @@ public final class ProfileEditViewController: UIViewController {
     private func setUpProfilePlaceHolder() {
         nicknameTextField.textField.placeholder = viewModel.userProfile.nickname
         profileEditButton.setProfileImage(with: viewModel.userProfile.profileCharacterType.image)
+        profileSelectionIndexPublisher.send(viewModel.userProfile.profileCharacterType.index)
     }
 }
 

--- a/Projects/Feature/MyPage/Interface/Sources/ViewControllers/ProfileEditViewController.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewControllers/ProfileEditViewController.swift
@@ -74,8 +74,8 @@ public final class ProfileEditViewController: UIViewController {
             }
             .store(in: &cancellables)
 
-        let profileSelectionPublisher = profileSelectionIndexPublisher
-            .map { ProfileCharacterType.allCases[$0].character }
+        let selectedProfilePublisher = selectedProfileTypePublisher
+            .map { $0.rawValue }
             .eraseToAnyPublisher()
 
         let nicknameTextPublisher = nicknameTextField.textField.textPublisher
@@ -86,7 +86,7 @@ public final class ProfileEditViewController: UIViewController {
 
         let input = ProfileEditViewModel.Input(
             nicknameTextPublisher: nicknameTextPublisher,
-            profileImagePublisher: profileSelectionPublisher,
+            profileImagePublisher: selectedProfilePublisher,
             saveButtonTapPublisher: saveButtonTapPublisher
         )
 
@@ -122,7 +122,7 @@ public final class ProfileEditViewController: UIViewController {
     private func setUpProfilePlaceHolder() {
         nicknameTextField.textField.placeholder = viewModel.userProfile.nickname
         profileEditButton.setProfileImage(with: viewModel.userProfile.profileCharacterType.image)
-        profileSelectionIndexPublisher.send(viewModel.userProfile.profileCharacterType.index)
+        selectedProfileTypePublisher.send(viewModel.userProfile.profileCharacterType)
     }
 }
 
@@ -151,7 +151,7 @@ private extension ProfileEditViewController {
         return profileView.saveProfileButton
     }
 
-    var profileSelectionIndexPublisher: CurrentValueSubject<Int, Never> {
-        return editProfileViewController.profileSelectionIndexPublisher
+    var selectedProfileTypePublisher: CurrentValueSubject<ProfileCharacterType, Never> {
+        return editProfileViewController.selectedProfileTypePublisher
     }
 }

--- a/Projects/Feature/MyPage/Interface/Sources/ViewModels/ProfileEditViewModel.swift
+++ b/Projects/Feature/MyPage/Interface/Sources/ViewModels/ProfileEditViewModel.swift
@@ -54,15 +54,12 @@ public final class ProfileEditViewModel {
 
 private extension ProfileEditViewModel {
     func isEnabledSaveButton(_ nickname: String?, _ profileCharacter: String) -> Bool {
-        let count = nickname?.count ?? 0
+        let nicknameWordCount = nickname?.count ?? 0
 
-        if let nickname = nickname {
-            return nickname.isEmpty == false && count <= 10 && userProfile.nickname != nickname && nickname.containsOnlyAllowedCharacters == true
-        } else if !profileCharacter.isEmpty {
-            return !profileCharacter.isEmpty && profileCharacter != userProfile.profileCharacterType.rawValue
-        }
+        let nicknameCondition = nickname?.isEmpty == false && nicknameWordCount <= 10 && userProfile.nickname != nickname && nickname?.containsOnlyAllowedCharacters == true
 
-        return false
+        let profileCondition = !profileCharacter.isEmpty && profileCharacter != userProfile.profileCharacterType.rawValue
+        return nicknameCondition || profileCondition
     }
 
     func isEnabledSaveButton(input: Input) -> AnyPublisher<Bool, Never> {

--- a/Projects/Feature/Onboarding/Interface/Sources/Components/Profile/ProfileView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/Components/Profile/ProfileView.swift
@@ -92,7 +92,12 @@ public final class ProfileView: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
 
-        flexContainer.pin.all(pin.safeArea)
+        flexContainer.pin
+            .top(pin.safeArea.top)
+            .left(pin.safeArea.left)
+            .right(pin.safeArea.right)
+            .bottom(21 + 12)
+
         flexContainer.flex.layout()
     }
 
@@ -141,7 +146,7 @@ public final class ProfileView: UIView {
                         flex.addItem(nextButton)
                             .minHeight(56)
                             .cornerRadius(8)
-                            .marginBottom(23)
+                            .marginBottom(pin.safeArea.bottom + 2)
                     }
             }
     }

--- a/Projects/Feature/Onboarding/Interface/Sources/Components/Profile/ProfileView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/Components/Profile/ProfileView.swift
@@ -96,7 +96,7 @@ public final class ProfileView: UIView {
             .top(pin.safeArea.top)
             .left(pin.safeArea.left)
             .right(pin.safeArea.right)
-            .bottom(21 + 12)
+            .bottom(21 + 23)
 
         flexContainer.flex.layout()
     }
@@ -146,7 +146,6 @@ public final class ProfileView: UIView {
                         flex.addItem(nextButton)
                             .minHeight(56)
                             .cornerRadius(8)
-                            .marginBottom(pin.safeArea.bottom + 2)
                     }
             }
     }

--- a/Projects/Feature/Onboarding/Interface/Sources/Components/UserInformationView.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/Components/UserInformationView.swift
@@ -89,7 +89,12 @@ final class UserInformationView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        flexContainer.pin.all(pin.safeArea)
+        flexContainer.pin
+            .top(pin.safeArea.top)
+            .left(pin.safeArea.left)
+            .right(pin.safeArea.right)
+            .bottom(21 + 23)
+
         flexContainer.flex.layout()
     }
 
@@ -138,7 +143,7 @@ final class UserInformationView: UIView {
                         flex.addItem(nextButton)
                             .minHeight(56)
                             .cornerRadius(8)
-                            .marginBottom(23)
+                            .marginBottom(pin.safeArea.bottom + 2)
                     }
             }
     }

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewControllers/EditProfileViewController.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewControllers/EditProfileViewController.swift
@@ -11,8 +11,9 @@ import Shared
 
 public final class EditProfileViewController: BottomSheetViewController<EditProfileView> {
     private var cancellables = Set<AnyCancellable>()
+    private var profileTypes = ProfileCharacterType.allCases
     private var selectedProfileIndex: Int = 0
-    public let profileSelectionIndexPublisher = CurrentValueSubject<Int, Never>(0)
+    public let selectedProfileTypePublisher = CurrentValueSubject<ProfileCharacterType, Never>(.shortHair)
 
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,8 +31,9 @@ public final class EditProfileViewController: BottomSheetViewController<EditProf
 
         selectButton.publisher(for: .touchUpInside)
             .sink { [weak self] (_) in
-                self?.profileSelectionIndexPublisher.send(self?.selectedProfileIndex ?? 0)
-                self?.dismiss(animated: true)
+                guard let self = self else { return }
+                selectedProfileTypePublisher.send(profileTypes[selectedProfileIndex])
+                dismiss(animated: true)
             }
             .store(in: &cancellables)
 

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewControllers/ProfileViewController.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewControllers/ProfileViewController.swift
@@ -63,8 +63,8 @@ public final class ProfileViewController: UIViewController {
             }
             .store(in: &cancellables)
 
-        let profileSelectionPublisher = profileSelectionIndexPublisher
-            .map { ProfileCharacterType.allCases[$0].character }
+        let selectedProfilePublisher = selectedProfileTypePublisher
+            .map { $0.rawValue }
             .eraseToAnyPublisher()
 
         let nicknameTextPublisher = nicknameTextField.textField.textPublisher
@@ -76,7 +76,7 @@ public final class ProfileViewController: UIViewController {
 
         let input = ProfileViewModel.Input(
             nicknameTextPublisher: nicknameTextPublisher,
-            profileImagePublisher: profileSelectionPublisher,
+            profileImagePublisher: selectedProfilePublisher,
             nextButtonTapPublisher: nextButtonPublisher
         )
 
@@ -128,7 +128,7 @@ private extension ProfileViewController {
         return profileView.nextButton
     }
 
-    var profileSelectionIndexPublisher: CurrentValueSubject<Int, Never> {
-        return editProfileViewController.profileSelectionIndexPublisher
+    var selectedProfileTypePublisher: CurrentValueSubject<ProfileCharacterType, Never> {
+        return editProfileViewController.selectedProfileTypePublisher
     }
 }

--- a/Projects/Feature/Onboarding/Interface/Sources/ViewControllers/UseAgreementViewController.swift
+++ b/Projects/Feature/Onboarding/Interface/Sources/ViewControllers/UseAgreementViewController.swift
@@ -77,7 +77,12 @@ public final class UseAgreementViewController: UIViewController {
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        rootFlexContainer.pin.all(self.view.pin.safeArea)
+        rootFlexContainer.pin
+            .top(self.view.pin.safeArea.top)
+            .left(self.view.pin.safeArea.left)
+            .right(self.view.pin.safeArea.right)
+            .bottom(21 + 23)
+
         rootFlexContainer.flex.layout()
     }
 

--- a/Projects/Shared/DesignSystem/Sources/Models/ProfileCharacterType.swift
+++ b/Projects/Shared/DesignSystem/Sources/Models/ProfileCharacterType.swift
@@ -31,19 +31,6 @@ public enum ProfileCharacterType: String, CaseIterable {
         }
     }
 
-    public var index: Int {
-        switch self {
-        case .shortHair:
-            return 0
-        case .braidedHair:
-            return 1
-        case .partedHair:
-            return 2
-        case .poopHair:
-            return 3
-        }
-    }
-
     public static let defaultImage = FeelinImages.profileShortHair
     public static let defaultCharacter = ProfileCharacterType.shortHair.character
 }

--- a/Projects/Shared/DesignSystem/Sources/Models/ProfileCharacterType.swift
+++ b/Projects/Shared/DesignSystem/Sources/Models/ProfileCharacterType.swift
@@ -31,6 +31,19 @@ public enum ProfileCharacterType: String, CaseIterable {
         }
     }
 
+    public var index: Int {
+        switch self {
+        case .shortHair:
+            return 0
+        case .braidedHair:
+            return 1
+        case .partedHair:
+            return 2
+        case .poopHair:
+            return 3
+        }
+    }
+
     public static let defaultImage = FeelinImages.profileShortHair
     public static let defaultCharacter = ProfileCharacterType.shortHair.character
 }


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [x] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:

## 배경

<!-- 해당 PR에서 개발한 내용에 대해 알아야 하는 배경지식을 작성해주세요. -->

- 특정 디바이스에서 safeArea Bottom 부분이 없는 경우, 회원가입 플로우에서 버튼이 붙어있음
  - 전체동의
  - 성별, 아이콘 설정
  - 프로필 설정

- 프로필 수정 페이지가 정상작동 안함
  - 아이콘 or 닉네임만 변경해도 수정가능해야 함 

-  iphone pro max에서 Favorite Artist 셀이 2줄로 나옴

- 중복 로그인 팝업 > 확인 > 앱을 이용할 수 없는 문제가 있음

## 목표

<!-- 해당 PR에서 개발/수정 한 기능의 목표를 작성해주세요. -->

- SafeArea Bottom의 높이는 21이므로 구체적인 숫자를 명시해서 해결
- 프로필 수정에서 버튼이 활성화되는 분기처리 수정
- Favorite Artist 셀의 width를 계산하는 로직 수정
- 중복 로그인 팝업 > 확인 버튼 클릭 시 > 로그인 화면으로 이동

## 결과 (Optional)

<!-- 개발한 내용의 결과를 설명해주세요. !-->

- Favorite Artist는 기존에 27에 맞춰서 계산해주고 있었지만 spacing 28로 늘려도 전체 디바이스에서 동일하게 적용됩니다.
- SplashCoordinator를 만들어서 Splash ViewController에서 중복 로그인 팝업이 뜨고 확인 버튼을 클릭하면 로그인 화면으로 넘어갈 수 있도록 변경했습니다.
  - Home, SearchNote, MyPage에서도 중복로그인 팝업 > didfinish 호출 시 로그인 화면으로 이동하는 것을 확인했습니다.

| 12pro max 기존 문제 | 수정된 부분 확인용 - 12pro max | 수정된 부분 확인용 - 15pro max | 
|--|--|--|
|<img src="https://github.com/user-attachments/assets/1a37f13e-c02b-4306-becb-3baa10dd8cb1" width="250">|<img  src="https://github.com/user-attachments/assets/6fca8733-e683-436c-a387-3c3c07416305"  width="250">|<img src="https://github.com/user-attachments/assets/391c6950-0cfc-492f-baed-7d5d315b0d8e" width="250">|

| 수정된 부분 확인용 - se | 수정된 부분 확인용 - 14pro |
|--|--|
|<img src="https://github.com/user-attachments/assets/95de5158-fbc2-4792-bc88-10137b949a94" width="250">|<img src="https://github.com/user-attachments/assets/5b06205b-673a-4308-a2f9-5e9ed7f8ef13" width="250">|
