### PR TITLE
Feature: 이벤트 팝업 & 배너 구현

### DIFF
--- a/Projects/Coordinator/Home/Interface/Sources/HomeCoordinatorInterface.swift
+++ b/Projects/Coordinator/Home/Interface/Sources/HomeCoordinatorInterface.swift
@@ -284,6 +284,7 @@ extension HomeCoordinator {
         let blockUserUseCase = BlockUserUseCase(userProfileAPIService: userProfileAPIService)
         let fetchSingleEventUseCase = FetchSingleEventUseCase(eventAPIService: eventAPIService)
         let refuseEventUseCase = RefuseEventUseCase(eventAPIService: eventAPIService)
+        let fetchBannersUseCase = FetchBannersUseCase(eventAPIService: eventAPIService)
 
         let viewModel =  HomeViewModel(
             getNotesUseCase: getNoteUseCase,
@@ -295,7 +296,8 @@ extension HomeCoordinator {
             checkFirstVisitorUseCase: checkFirstVisitorUseCase,
             blockUserUseCase: blockUserUseCase,
             fetchSingleEventUseCase: fetchSingleEventUseCase,
-            refuseEventUseCase: refuseEventUseCase
+            refuseEventUseCase: refuseEventUseCase,
+            fetchBannersUseCase: fetchBannersUseCase
         )
 
         return viewModel

--- a/Projects/Coordinator/Home/Interface/Sources/HomeCoordinatorInterface.swift
+++ b/Projects/Coordinator/Home/Interface/Sources/HomeCoordinatorInterface.swift
@@ -77,14 +77,9 @@ public final class HomeCoordinator: Coordinator {
 
             return NotificationAPIService(networkProvider: networkProvider)
         }
-        
-        DIContainer.standard.register(.userProfileAPIService) { resolver in
-            let networkProvider = try resolver.resolve(.networkProvider)
-            
-            return UserProfileAPIService(networkProvider: networkProvider)
-        }
 
         DIContainer.registerUserProfileService()
+        DIContainer.registerEventAPIService()
     }
 
     private func registerNoteCommentDI() {
@@ -266,6 +261,7 @@ extension HomeCoordinator {
         @Injected(.artistPaginationService) var artistPaginationService: KeywordPaginationServiceInterface
         @Injected(.notificationAPIService) var notificationAPIService: NotificationAPIServiceInterface
         @Injected(.userProfileAPIService) var userProfileAPIService: UserProfileAPIServiceInterface
+        @Injected(.eventAPIService) var eventAPIService: EventAPIServiceInterface
 
         @KeychainWrapper<UserInformation>(.userInfo)
         var userInfo
@@ -286,6 +282,8 @@ extension HomeCoordinator {
         let getHasUncheckedNotificationUseCase = GetHasUncheckedNotificationUseCase(notificationAPIService: notificationAPIService)
         let checkFirstVisitorUseCase = CheckFirstVisitorUseCase(userProfileAPIService: userProfileAPIService)
         let blockUserUseCase = BlockUserUseCase(userProfileAPIService: userProfileAPIService)
+        let fetchSingleEventUseCase = FetchSingleEventUseCase(eventAPIService: eventAPIService)
+        let refuseEventUseCase = RefuseEventUseCase(eventAPIService: eventAPIService)
 
         let viewModel =  HomeViewModel(
             getNotesUseCase: getNoteUseCase,
@@ -295,7 +293,9 @@ extension HomeCoordinator {
             deleteNoteUseCase: deleteNoteUseCase,
             getHasUncheckedNotificationUseCase: getHasUncheckedNotificationUseCase,
             checkFirstVisitorUseCase: checkFirstVisitorUseCase,
-            blockUserUseCase: blockUserUseCase
+            blockUserUseCase: blockUserUseCase,
+            fetchSingleEventUseCase: fetchSingleEventUseCase,
+            refuseEventUseCase: refuseEventUseCase
         )
 
         return viewModel

--- a/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
+++ b/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
@@ -58,6 +58,8 @@ public enum FeelinAPI<R> {
     case getBlockedUsers
     case deleteUser
     case checkFirstVisitor
+    case getEvents
+    case postEventRefuse(eventID: Int)
 }
 
 extension FeelinAPI: HTTPNetworking {
@@ -205,6 +207,11 @@ extension FeelinAPI: HTTPNetworking {
              .deleteBlockUserProfile(let userID):
             return [
                 "userId": userID
+            ]
+            
+        case .postEventRefuse(let eventID):
+            return [
+                "eventId": eventID
             ]
             
         default:
@@ -380,6 +387,12 @@ extension FeelinAPI: HTTPNetworking {
             
         case .getBlockedUsers:
             return "/api/v1/users/blocks"
+            
+        case .getEvents:
+            return "/api/v1/events"
+            
+        case .postEventRefuse:
+            return "/api/v1/events/refuse"
         }
     }
 
@@ -395,7 +408,8 @@ extension FeelinAPI: HTTPNetworking {
              .postComment, 
              .reportNote,
              .postFavoriteArtist,
-             .postBlockUserProfile:
+             .postBlockUserProfile,
+             .postEventRefuse:
             return .post
 
         case .checkUserValidity, 
@@ -420,7 +434,8 @@ extension FeelinAPI: HTTPNetworking {
              .getUserProfile,
              .checkFirstVisitor,
              .getMyNotesByBookmark,
-             .getBlockedUsers:
+             .getBlockedUsers,
+             .getEvents:
             return .get
             
         case .deleteLikes, 

--- a/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
+++ b/Projects/Core/Network/Interface/Sources/API/FeelinAPI.swift
@@ -60,6 +60,7 @@ public enum FeelinAPI<R> {
     case checkFirstVisitor
     case getEvents
     case postEventRefuse(eventID: Int)
+    case getBanners
 }
 
 extension FeelinAPI: HTTPNetworking {
@@ -393,6 +394,9 @@ extension FeelinAPI: HTTPNetworking {
             
         case .postEventRefuse:
             return "/api/v1/events/refuse"
+            
+        case .getBanners:
+            return "/api/v1/banners"
         }
     }
 
@@ -435,7 +439,8 @@ extension FeelinAPI: HTTPNetworking {
              .checkFirstVisitor,
              .getMyNotesByBookmark,
              .getBlockedUsers,
-             .getEvents:
+             .getEvents,
+             .getBanners:
             return .get
             
         case .deleteLikes, 

--- a/Projects/Core/Network/Interface/Sources/DTO/Response/GetBannerResponse.swift
+++ b/Projects/Core/Network/Interface/Sources/DTO/Response/GetBannerResponse.swift
@@ -1,0 +1,24 @@
+//
+//  GetBannerResponse.swift
+//  CoreNetworkInterface
+//
+//  Created by 황인우 on 3/19/25.
+//
+
+import Foundation
+
+public struct GetBannerResponse: Decodable {
+    public let id: Int
+    public let imageUrl: URL
+    public let redirectUrl: URL
+    
+    public init(
+        id: Int,
+        imageUrl: URL,
+        redirectUrl: URL
+    ) {
+        self.id = id
+        self.imageUrl = imageUrl
+        self.redirectUrl = redirectUrl
+    }
+}

--- a/Projects/Core/Network/Interface/Sources/DTO/Response/GetEventsResponse.swift
+++ b/Projects/Core/Network/Interface/Sources/DTO/Response/GetEventsResponse.swift
@@ -1,0 +1,26 @@
+//
+//  GetEventsResponse.swift
+//  CoreNetworkInterface
+//
+//  Created by 황인우 on 3/10/25.
+//
+
+import Foundation
+
+public struct GetEventInfoResponse: Decodable {
+    public let refusalPeriod: Int
+    public let event: GetEventResponse
+}
+
+public struct GetEventResponse: Decodable {
+    public let nextCursor: Int?
+    public let hasNext: Bool
+    public let data: [GetEventDetailResponse]
+}
+
+public struct GetEventDetailResponse: Decodable {
+    public let id: Int
+    public let imageUrl: URL
+    public let redirectUrl: URL
+    public let buttonText: String
+}

--- a/Projects/Core/Network/Sources/Extensions/Publisher+.swift
+++ b/Projects/Core/Network/Sources/Extensions/Publisher+.swift
@@ -17,6 +17,10 @@ public extension Publisher where Output == DataTaskResult {
                 throw NetworkError.noResponseError
             }
             
+            // 응답 로그 출력
+//            let responseString = String(data: data, encoding: .utf8) ?? " 데이터를 문자열로 변환할 수 없음"
+//            AppLogger.log("🔹 [Response Body]: \(responseString)")
+            
             if let feelinServerFailResponse = try? decoder.decode(APIFailResponse.self, from: data) {
                 throw NetworkError.feelinAPIError(
                     .init(apiFailResponse: feelinServerFailResponse)

--- a/Projects/DependencyInjection/Sources/DIContainer/DIContainer.swift
+++ b/Projects/DependencyInjection/Sources/DIContainer/DIContainer.swift
@@ -205,3 +205,14 @@ public extension DIContainer {
         }
     }
 }
+
+// MARK: Report && Notification
+
+public extension DIContainer {
+    static func registerEventAPIService() {
+        standard.register(.eventAPIService) { resolver in
+            let networkProvider = try resolver.resolve(.networkProvider)
+            return EventAPIService(networkProvider: networkProvider)
+        }
+    }
+}

--- a/Projects/DependencyInjection/Sources/DIContainer/Inject/InjectIdentifier.swift
+++ b/Projects/DependencyInjection/Sources/DIContainer/Inject/InjectIdentifier.swift
@@ -108,6 +108,13 @@ public extension InjectIdentifier {
     static var userProfileAPIService: InjectIdentifier<UserProfileAPIServiceInterface> {
         .by(type: UserProfileAPIServiceInterface.self, key: "userProfileAPIService")
     }
+    
+    static var eventAPIService: InjectIdentifier<EventAPIServiceInterface> {
+        .by(
+            type: EventAPIServiceInterface.self,
+            key: "eventAPIService"
+        )
+    }
 }
 
 extension InjectIdentifier: Hashable {

--- a/Projects/Domain/Shared/Interface/Sources/Errors/EventError.swift
+++ b/Projects/Domain/Shared/Interface/Sources/Errors/EventError.swift
@@ -1,0 +1,83 @@
+//
+//  EventError.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/10/25.
+//
+
+import Foundation
+
+import Core
+import Shared
+
+public enum EventError: LocalizedError, Equatable {
+    case feelinAPIError(FeelinAPIError)
+    case networkError(NetworkError)
+    case keychainError(KeychainError)
+    case unknown(errorDescription: String)
+    
+    public var errorMessage: String {
+        switch self {
+        case .networkError(let error):
+            return error.errorMessage
+            
+        case .keychainError(let error):
+            return error.errorMessage
+            
+        case .unknown(let errorDescription):
+            return errorDescription
+            
+        case .feelinAPIError(let error):
+            return error.errorMessage
+        }
+    }
+    
+    public var errorCode: String? {
+        switch self {
+        case .feelinAPIError(let feelinAPIError):
+            return feelinAPIError.errorCode
+        case .networkError(let networkError):
+            return networkError.errorCode
+        default:
+            return nil
+        }
+    }
+    
+    public var errorMessageWithCode: String {
+        return errorMessage + "\n에러코드(\(errorCode ?? "nil"))"
+    }
+    
+    public var userMessage: String {
+        switch self {
+        case .feelinAPIError(let feelinAPIError):
+            return feelinAPIError.userMessage
+            
+        default:
+            return "클라이언트 오류입니다. \n잠시 후 다시 시도해 주세요."
+        }
+    }
+    
+    public var data: AnyType? {
+        switch self {
+        case .feelinAPIError(let feelinAPIError):
+            return feelinAPIError.data
+            
+        default:
+            return nil
+        }
+    }
+    
+    public init(error: Error) {
+        if let networkError = error as? NetworkError {
+            if case .feelinAPIError(let feelinAPIError) = networkError {
+                self = .feelinAPIError(feelinAPIError)
+            } else {
+                self = .networkError(networkError)
+            }
+        } else if let keychainError = error as? KeychainError {
+            self = .keychainError(keychainError)
+        } else {
+            self = .unknown(errorDescription: error.localizedDescription)
+        }
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/Models/Banner.swift
+++ b/Projects/Domain/Shared/Interface/Sources/Models/Banner.swift
@@ -1,0 +1,33 @@
+//
+//  Banner.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/19/25.
+//
+
+import UIKit
+
+import Core
+import Shared
+
+public struct Banner: Hashable {
+    public let id: Int
+    public let imageUrl: URL
+    public let redirectUrl: URL
+    
+    public init(
+        id: Int,
+        imageUrl: URL,
+        redirectUrl: URL
+    ) {
+        self.id = id
+        self.imageUrl = imageUrl
+        self.redirectUrl = redirectUrl
+    }
+    
+    public init(dto: GetBannerResponse) {
+        self.id = dto.id
+        self.imageUrl = dto.imageUrl
+        self.redirectUrl = dto.redirectUrl
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/Models/FeelinEvent.swift
+++ b/Projects/Domain/Shared/Interface/Sources/Models/FeelinEvent.swift
@@ -1,0 +1,70 @@
+//
+//  FeelinEvent.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/10/25.
+//
+
+import Core
+
+import Foundation
+
+public struct EventExtraInfo: Hashable {
+    public let buttonTitle: String
+    public let refusalText: String
+    
+    public init(
+        buttonTitle: String,
+        refusalPeriod: Int
+    ) {
+        self.buttonTitle = buttonTitle
+        self.refusalText = Self.makeRefusalText(
+            from: refusalPeriod
+        )
+    }
+    
+    private static func makeRefusalText(from period: Int) -> String {
+        switch period {
+        case 1:
+            return "오늘 하루 보지 않기"
+        case 7:
+            return "일주일간 보지 않기"
+        case 30:
+            return "한 달 동안 보지 않기"
+        default:
+            return "\(period)일간 보지 않기"
+        }
+    }
+}
+
+public struct FeelinEvent: Hashable {
+    public let id: Int
+    public let imageURL: URL
+    public let redirectURL: URL
+    public let eventExtraInfo: EventExtraInfo
+    
+    public init(
+        id: Int,
+        imageURL: URL,
+        redirectURL: URL,
+        eventExtraInfo: EventExtraInfo
+    ) {
+        self.id = id
+        self.imageURL = imageURL
+        self.redirectURL = redirectURL
+        self.eventExtraInfo = eventExtraInfo
+    }
+    
+    public init(
+        dto: GetEventDetailResponse,
+        refusalPeriod: Int
+    ) {
+        self.id = dto.id
+        self.imageURL = dto.imageUrl
+        self.redirectURL = dto.redirectUrl
+        self.eventExtraInfo = .init(
+            buttonTitle: dto.buttonText,
+            refusalPeriod: refusalPeriod
+        )
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/Services/EventAPIService.swift
+++ b/Projects/Domain/Shared/Interface/Sources/Services/EventAPIService.swift
@@ -13,6 +13,7 @@ import Foundation
 public protocol EventAPIServiceInterface {
     func getEvents() -> AnyPublisher<GetEventInfoResponse, EventError>
     func postEventRefuse(eventID: Int) -> AnyPublisher<FeelinSuccessResponse, EventError>
+    func getBanners() -> AnyPublisher<[GetBannerResponse], EventError>
 }
 
 public struct EventAPIService: EventAPIServiceInterface {
@@ -32,6 +33,14 @@ public struct EventAPIService: EventAPIServiceInterface {
     
     public func postEventRefuse(eventID: Int) -> AnyPublisher<FeelinSuccessResponse, EventError> {
         let endpoint = FeelinAPI<FeelinSuccessResponse>.postEventRefuse(eventID: eventID)
+        
+        return networkProvider.request(endpoint)
+            .mapError(EventError.init)
+            .eraseToAnyPublisher()
+    }
+    
+    public func getBanners() -> AnyPublisher<[GetBannerResponse], EventError> {
+        let endpoint = FeelinAPI<[GetBannerResponse]>.getBanners
         
         return networkProvider.request(endpoint)
             .mapError(EventError.init)

--- a/Projects/Domain/Shared/Interface/Sources/Services/EventAPIService.swift
+++ b/Projects/Domain/Shared/Interface/Sources/Services/EventAPIService.swift
@@ -1,0 +1,40 @@
+//
+//  EventAPIService.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/10/25.
+//
+
+import Core
+
+import Combine
+import Foundation
+
+public protocol EventAPIServiceInterface {
+    func getEvents() -> AnyPublisher<GetEventInfoResponse, EventError>
+    func postEventRefuse(eventID: Int) -> AnyPublisher<FeelinSuccessResponse, EventError>
+}
+
+public struct EventAPIService: EventAPIServiceInterface {
+    let networkProvider: NetworkProviderInterface
+    
+    public init(networkProvider: NetworkProviderInterface) {
+        self.networkProvider = networkProvider
+    }
+    
+    public func getEvents() -> AnyPublisher<GetEventInfoResponse, EventError> {
+        let endpoint = FeelinAPI<GetEventInfoResponse>.getEvents
+        
+        return networkProvider.request(endpoint)
+            .mapError(EventError.init)
+            .eraseToAnyPublisher()
+    }
+    
+    public func postEventRefuse(eventID: Int) -> AnyPublisher<FeelinSuccessResponse, EventError> {
+        let endpoint = FeelinAPI<FeelinSuccessResponse>.postEventRefuse(eventID: eventID)
+        
+        return networkProvider.request(endpoint)
+            .mapError(EventError.init)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/UseCasess/FetchBannersUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCasess/FetchBannersUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  FetchBannersUseCase.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/19/25.
+//
+
+import Core
+
+import Foundation
+import Combine
+
+public protocol FetchBannersUseCaseInterface {
+    func execute() -> AnyPublisher<[Banner], EventError>
+}
+
+public struct FetchBannersUseCase: FetchBannersUseCaseInterface {
+    private let eventAPIService: EventAPIServiceInterface
+    
+    public init(eventAPIService: EventAPIServiceInterface) {
+        self.eventAPIService = eventAPIService
+    }
+    
+    public func execute() -> AnyPublisher<[Banner], EventError> {
+        return eventAPIService.getBanners()
+            .receive(on: DispatchQueue.main)
+            .map { $0.map(Banner.init) }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/UseCasess/FetchSingleEventUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCasess/FetchSingleEventUseCase.swift
@@ -24,6 +24,8 @@ public struct FetchSingleEventUseCase: FetchSingleEventUseCaseInterface {
     public func execute() -> AnyPublisher<FeelinEvent, EventError> {
         return eventAPIService.getEvents()
             .compactMap { response in
+                // 받아온 데이터 중 하나만 필요로 하기에 첫 번째 값만 매핑하였습니다.
+                // 서버로부터 데이터를 한 개만 받는 것이 확실하기에 last를 써도 무방합니다.
                 response.event.data.first.map {
                     FeelinEvent(
                         dto: $0,

--- a/Projects/Domain/Shared/Interface/Sources/UseCasess/FetchSingleEventUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCasess/FetchSingleEventUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  FetchSingleEventUseCase.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/10/25.
+//
+
+import Core
+
+import Foundation
+import Combine
+
+public protocol FetchSingleEventUseCaseInterface {
+    func execute() -> AnyPublisher<FeelinEvent, EventError>
+}
+
+public struct FetchSingleEventUseCase: FetchSingleEventUseCaseInterface {
+    private let eventAPIService: EventAPIServiceInterface
+    
+    public init(eventAPIService: EventAPIServiceInterface) {
+        self.eventAPIService = eventAPIService
+    }
+    
+    public func execute() -> AnyPublisher<FeelinEvent, EventError> {
+        return eventAPIService.getEvents()
+            .compactMap { response in
+                response.event.data.first.map {
+                    FeelinEvent(
+                        dto: $0,
+                        refusalPeriod: response.refusalPeriod
+                    )
+                }
+            }
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Domain/Shared/Interface/Sources/UseCasess/RefuseEventUseCase.swift
+++ b/Projects/Domain/Shared/Interface/Sources/UseCasess/RefuseEventUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  RefuseEventUseCase.swift
+//  DomainShared
+//
+//  Created by 황인우 on 3/10/25.
+//
+
+import Core
+
+import Foundation
+import Combine
+
+public protocol RefuseEventUseCaseInterface {
+    func execute(eventID: Int) -> AnyPublisher<Bool, EventError>
+}
+
+public struct RefuseEventUseCase: RefuseEventUseCaseInterface {
+    private let eventAPIService: EventAPIServiceInterface
+    
+    public init(eventAPIService: EventAPIServiceInterface) {
+        self.eventAPIService = eventAPIService
+    }
+    
+    public func execute(eventID: Int) -> AnyPublisher<Bool, EventError> {
+        return eventAPIService.postEventRefuse(eventID: eventID)
+            .receive(on: DispatchQueue.main)
+            .map(\.success)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Feature/Home/Example/Sources/SceneDelegate.swift
+++ b/Projects/Feature/Home/Example/Sources/SceneDelegate.swift
@@ -345,6 +345,10 @@ extension SceneDelegate {
 }
 
 extension SceneDelegate: PostNoteViewControllerDelegate, SearchSongViewControllerDelegate {
+    func handleError(errorCode: String?, errorMessage: String, errorData: SharedUtil.AnyType?) {
+        
+    }
+    
     func popRootViewController() {
         
     }

--- a/Projects/Feature/Home/Interface/Sources/Errors/HomeError.swift
+++ b/Projects/Feature/Home/Interface/Sources/Errors/HomeError.swift
@@ -14,6 +14,7 @@ public enum HomeError: LocalizedError, Equatable {
     case noteError(NoteError)
     case artistError(ArtistError)
     case userProfileError(UserProfileError)
+    case eventError(EventError)
     case unknownError(description: String)
     
     public init(error: Error) {
@@ -23,6 +24,8 @@ public enum HomeError: LocalizedError, Equatable {
             self = .noteError(noteError)
         } else if let userProfileError = error as? UserProfileError {
             self = .userProfileError(userProfileError)
+        } else if let eventError = error as? EventError {
+            self = .eventError(eventError)
         } else {
             self = .unknownError(description: error.localizedDescription)
         }
@@ -38,6 +41,9 @@ public enum HomeError: LocalizedError, Equatable {
             
         case .userProfileError(let userProfileError):
             return userProfileError.errorMessage + "에러코드: \(userProfileError.errorCode ?? "nil")"
+        
+        case .eventError(let eventError):
+            return eventError.errorMessage + "에러코드: \(eventError.errorCode ?? "nil")"
             
         case .unknownError(let description):
             return description
@@ -59,6 +65,9 @@ public enum HomeError: LocalizedError, Equatable {
         case .userProfileError(let userProfileError):
             return userProfileError.userMessage
             
+        case .eventError(let eventError):
+            return eventError.userMessage
+            
         case .unknownError(let unknownError):
             return unknownError
         }
@@ -74,6 +83,9 @@ public enum HomeError: LocalizedError, Equatable {
             
         case .userProfileError(let userProfileError):
             return userProfileError.data
+            
+        case .eventError(let eventError):
+            return eventError.data
         
         default:
             return nil
@@ -88,6 +100,8 @@ public enum HomeError: LocalizedError, Equatable {
             return artistError.errorCode
         case .userProfileError(let userProfileError):
             return userProfileError.errorCode
+        case .eventError(let eventError):
+            return eventError.errorCode
         case .unknownError:
             return nil
         }

--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/HomeViewController.swift
@@ -60,7 +60,10 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     private typealias HomeDataSource = UICollectionViewDiffableDataSource<CollectionContent.Section, CollectionContent.Item>
     
     private lazy var homeDataSource: HomeDataSource = {
-        let bannerCellRegistration = UICollectionView.CellRegistration<BannerCell, Void> { cell, indexPath, item in }
+        let bannerCellRegistration = UICollectionView.CellRegistration<BannerCell, Banner> { cell, indexPath, item in
+            cell.configure(imageURL: item.imageUrl)
+        }
+        
         let searchArtistCellRegistration = UICollectionView.CellRegistration<SearchArtistCell, Void> { cell, indexPath, item in }
         let favoriteArtistCellRegistration = UICollectionView.CellRegistration<FeelinArtistCell, Artist> { cell, indexPath, artist in
             cell.configure(artistName: artist.name, artistImageURL: try? artist.imageSource?.asURL())
@@ -206,15 +209,17 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
         self.view = homeView
     }
 
-    private func updateBanner() {
+    private func updateBanner(_ banners: [Banner]) {
         var snapshot = homeDataSource.snapshot()
+        
+        let newItems = banners.map { CollectionContent.Item.banner($0) }
 
         // 배너 섹션이 없는 경우 추가
         if !snapshot.sectionIdentifiers.contains(.banner) {
             snapshot.appendSections([.banner])
-            snapshot.appendItems([.banner], toSection: .banner)
         }
-        homeDataSource.apply(snapshot, animatingDifferences: false)
+        snapshot.appendItems(newItems, toSection: .banner)
+        homeDataSource.applySnapshotUsingReloadData(snapshot)
     }
 
     private func updateFavoriteArtists(_ favoriteArtists: [Artist]) {
@@ -325,12 +330,10 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.checkFeelinEvent()
         
-        if self.isLoggedIn {
-            self.updateInitialHomeData()
-            self.checkForUnReadNotification()
-        }
+        self.checkFeelinEvent()
+        self.checkForUnReadNotification()
+        self.updateInitialHomeData()
     }
     
     private func setUpDefault() {
@@ -342,7 +345,11 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     // MARK: - Favorite Artists
     
     public func updateInitialHomeData() {
-        self.viewModel.fetchArtistsAndNotes()
+        if self.isLoggedIn {
+            self.viewModel.fetchHomeData()
+        } else {
+            self.viewModel.fetchBanners()
+        }
     }
     
     private func showSelectArtistListIfNeeded() {
@@ -354,7 +361,9 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     // MARK: - Notification Check
     
     private func checkForUnReadNotification() {
-        self.viewModel.checkForUnReadNotification()
+        if self.isLoggedIn {
+            self.viewModel.checkForUnReadNotification()
+        }
     }
 
     // MARK: - First Visitor Check
@@ -368,6 +377,10 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     private func checkFeelinEvent() {
         self.viewModel.fetchFeelinEvent()
     }
+    
+    private func updateBanners() {
+        self.viewModel.fetchBanners()
+    }
 }
 
 private extension HomeViewController {
@@ -375,8 +388,6 @@ private extension HomeViewController {
     // MARK: - Bindings
 
     func bindUI() {
-        self.updateBanner()
-
         viewModel.$error
             .compactMap { $0 }
             .sink { [weak self] error in
@@ -406,6 +417,12 @@ private extension HomeViewController {
                     return
                 }
             })
+            .store(in: &cancellables)
+        
+        viewModel.$fetchedBanners
+            .sink { [weak self] banners in
+                self?.updateBanner(banners)
+            }
             .store(in: &cancellables)
 
         viewModel.$fetchedFavoriteArtists
@@ -440,13 +457,9 @@ private extension HomeViewController {
             .sink { [weak self] result in
                 switch result {
                 case .success:
-                    if self?.isLoggedIn == true {
-                        self?.updateInitialHomeData()
-                        self?.checkForUnReadNotification()
-                    } else {
-                        // 로그아웃 된 상태에서는 올 수 없음
-                    }
-
+                    self?.checkForUnReadNotification()
+                    self?.updateInitialHomeData()
+                    
                 case .failure(let error):
                     self?.coordinator?.handleError(
                         errorCode: error.errorCode,
@@ -516,8 +529,8 @@ private extension HomeViewController {
                 guard let item = self.homeDataSource.itemIdentifier(for: indexPath) else { return }
 
                 switch item {
-                case .banner:
-                    self.openWebBrowser(urlStr: "https://docs.google.com/forms/d/1eoPqnYLfwlgmOeCSKrPWUb7qCPnX6QrLJx8r34WAUwk/edit")
+                case .banner(let banner):
+                    self.openWebBrowser(url: banner.redirectUrl)
 
                 case .searchArtist:
                     coordinator?.presentSearchMoreFavoriteArtistViewController()
@@ -581,10 +594,7 @@ private extension HomeViewController {
             .store(in: &cancellables)
     }
     
-    private func openWebBrowser(urlStr: String) {
-        guard let url = URL(string: urlStr) else {
-            return
-        }
+    private func openWebBrowser(url: URL) {
         if UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
         }
@@ -611,7 +621,7 @@ struct CollectionContent {
     }
     
     enum Item: Hashable {
-        case banner
+        case banner(Banner)
         case favoriteArtist(Artist)
         case searchArtist
         case note(Note)
@@ -622,7 +632,7 @@ struct CollectionContent {
 extension CollectionContent.Item {
     func dequeueConfiguredReusableCell(
         collectionView: UICollectionView,
-        bannerCellRegistration: UICollectionView.CellRegistration<BannerCell, Void>,
+        bannerCellRegistration: UICollectionView.CellRegistration<BannerCell, Banner>,
         searchArtistCellRegistration: UICollectionView.CellRegistration<SearchArtistCell, Void>,
         favoriteArtistCellRegistration: UICollectionView.CellRegistration<FeelinArtistCell, Artist>,
         emptyNoteCellRegistration: UICollectionView.CellRegistration<EmptyNoteCell, Void>,
@@ -630,11 +640,11 @@ extension CollectionContent.Item {
         indexPath: IndexPath
     ) -> UICollectionViewCell {
         switch self {
-        case .banner:
+        case .banner(let banner):
             return collectionView.dequeueConfiguredReusableCell(
                 using: bannerCellRegistration,
                 for: indexPath,
-                item: ()
+                item: banner
             )
         case .favoriteArtist(let artist):
             return collectionView.dequeueConfiguredReusableCell(

--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/HomeViewController.swift
@@ -213,13 +213,22 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
         var snapshot = homeDataSource.snapshot()
         
         let newItems = banners.map { CollectionContent.Item.banner($0) }
-
-        // 배너 섹션이 없는 경우 추가
-        if !snapshot.sectionIdentifiers.contains(.banner) {
+        
+        // 배너 섹션이 있는지 확인
+        if snapshot.sectionIdentifiers.contains(.banner) {
+            // 기존 아이템 삭제
+            let existingItems = snapshot.itemIdentifiers(inSection: .banner)
+            snapshot.deleteItems(existingItems)
+        } else {
+            // 섹션이 없으면 추가
             snapshot.appendSections([.banner])
         }
+        
+        // 새로운 아이템 추가
         snapshot.appendItems(newItems, toSection: .banner)
-        homeDataSource.applySnapshotUsingReloadData(snapshot)
+        
+        // 스냅샷 적용
+        homeDataSource.apply(snapshot)
     }
 
     private func updateFavoriteArtists(_ favoriteArtists: [Artist]) {

--- a/Projects/Feature/Home/Interface/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewControllers/HomeViewController.swift
@@ -325,6 +325,8 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.checkFeelinEvent()
+        
         if self.isLoggedIn {
             self.updateInitialHomeData()
             self.checkForUnReadNotification()
@@ -359,6 +361,12 @@ public class HomeViewController: UIViewController, NoteMenuHandling, NoteMusicHa
 
     private func checkFirstVisitor() {
         self.viewModel.checkFirstVisitor()
+    }
+    
+    // MARK: - Event Check
+    
+    private func checkFeelinEvent() {
+        self.viewModel.fetchFeelinEvent()
     }
 }
 
@@ -468,6 +476,24 @@ private extension HomeViewController {
                 default:
                     break
                 }
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$feelinEvent
+            .compactMap { $0 }
+            .sink { [weak self] event in
+                self?.showEventPopUp(
+                    contentImageUrl: event.imageURL,
+                    leftTopActionTitle: event.eventExtraInfo.refusalText,
+                    leftTopActionCompletion: {
+                        self?.viewModel.refuseEvent(eventId: event.id)
+                    },
+                    rightTopActionCompletion: nil,
+                    bottomActionTitle: event.eventExtraInfo.buttonTitle,
+                    bottomActionCompletion: {
+                        UIApplication.shared.open(event.redirectURL)
+                    }
+                )
             }
             .store(in: &cancellables)
             

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/HomeViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/HomeViewModel.swift
@@ -23,6 +23,7 @@ final public class HomeViewModel {
     @Published private (set) var deleteNoteResult: DeleteNoteResult = .none
     @Published private (set) var blockUserResult: BlockUserResult<HomeError> = .none
     @Published private (set) var feelinEvent: FeelinEvent?
+    @Published private (set) var fetchedBanners: [Banner] = []
 
     private let getNotesUseCase: GetNotesUseCaseInterface
     private let getFavoriteArtistsUseCase: GetFavoriteArtistsUseCaseInterface
@@ -34,6 +35,7 @@ final public class HomeViewModel {
     private let blockUserUseCase: BlockUserUseCaseInterface
     private let fetchSingleEventUseCase: FetchSingleEventUseCaseInterface
     private let refuseEventUseCase: RefuseEventUseCaseInterface
+    private let fetchBannersUseCase: FetchBannersUseCaseInterface
 
     private var cancellables: Set<AnyCancellable> = .init()
     
@@ -47,7 +49,8 @@ final public class HomeViewModel {
         checkFirstVisitorUseCase: CheckFirstVisitorUseCaseInterface,
         blockUserUseCase: BlockUserUseCaseInterface,
         fetchSingleEventUseCase: FetchSingleEventUseCaseInterface,
-        refuseEventUseCase: RefuseEventUseCaseInterface
+        refuseEventUseCase: RefuseEventUseCaseInterface,
+        fetchBannersUseCase: FetchBannersUseCaseInterface
     ) {
         self.getNotesUseCase = getNotesUseCase
         self.setNoteLikeUseCase = setNoteLikeUseCase
@@ -59,12 +62,17 @@ final public class HomeViewModel {
         self.checkFirstVisitorUseCase = checkFirstVisitorUseCase
         self.fetchSingleEventUseCase = fetchSingleEventUseCase
         self.refuseEventUseCase = refuseEventUseCase
+        self.fetchBannersUseCase = fetchBannersUseCase
     }
     
-    func fetchArtistsAndNotes(
+    func fetchHomeData(
         notesPerPage: Int = 10,
         artistsPerPage: Int = 30
     ) {
+        let getBanners = self.fetchBannersUseCase.execute()
+            .mapError(HomeError.init)
+            .eraseToAnyPublisher()
+        
         let getFavoriteArtists = self.getFavoriteArtistsUseCase.execute(
             isInitial: true,
             perPage: artistsPerPage
@@ -80,12 +88,13 @@ final public class HomeViewModel {
         .mapError(HomeError.init)
         .eraseToAnyPublisher()
         
-        Publishers.Zip(getFavoriteArtists, getRelatedNotes)
+        Publishers.Zip3(getBanners, getFavoriteArtists, getRelatedNotes)
             .receive(on: DispatchQueue.main)
             .mapToResult()
             .sink { [weak self] result in
                 switch result {
-                case .success(let (favoriteArtists, relatedNotes)):
+                case .success(let (banners, favoriteArtists, relatedNotes)):
+                    self?.fetchedBanners = banners
                     self?.fetchedFavoriteArtists = favoriteArtists
                     self?.fetchedNotes = relatedNotes
                 case .failure(let error):
@@ -388,5 +397,20 @@ extension HomeViewModel {
         } else {
             self.error = .eventError(.unknown(errorDescription: "이벤트 id를 찾을 수 없습니다."))
         }
+    }
+    
+    func fetchBanners() {
+        self.fetchBannersUseCase.execute()
+            .mapToResult()
+            .sink { [weak self] result in
+                switch result {
+                case .success(let banners):
+                    self?.fetchedBanners = banners
+                    
+                case .failure(let error):
+                    self?.error = .eventError(error)
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Projects/Feature/Home/Interface/Sources/ViewModels/HomeViewModel.swift
+++ b/Projects/Feature/Home/Interface/Sources/ViewModels/HomeViewModel.swift
@@ -22,6 +22,7 @@ final public class HomeViewModel {
     @Published private (set) var isFirstVisitor: Bool = false
     @Published private (set) var deleteNoteResult: DeleteNoteResult = .none
     @Published private (set) var blockUserResult: BlockUserResult<HomeError> = .none
+    @Published private (set) var feelinEvent: FeelinEvent?
 
     private let getNotesUseCase: GetNotesUseCaseInterface
     private let getFavoriteArtistsUseCase: GetFavoriteArtistsUseCaseInterface
@@ -31,6 +32,8 @@ final public class HomeViewModel {
     private let getHasUncheckedNotificationUseCase: GetHasUncheckedNotificationUseCaseInterface
     private let checkFirstVisitorUseCase: CheckFirstVisitorUseCaseInterface
     private let blockUserUseCase: BlockUserUseCaseInterface
+    private let fetchSingleEventUseCase: FetchSingleEventUseCaseInterface
+    private let refuseEventUseCase: RefuseEventUseCaseInterface
 
     private var cancellables: Set<AnyCancellable> = .init()
     
@@ -42,7 +45,9 @@ final public class HomeViewModel {
         deleteNoteUseCase: DeleteNoteUseCaseInterface,
         getHasUncheckedNotificationUseCase: GetHasUncheckedNotificationUseCaseInterface,
         checkFirstVisitorUseCase: CheckFirstVisitorUseCaseInterface,
-        blockUserUseCase: BlockUserUseCaseInterface
+        blockUserUseCase: BlockUserUseCaseInterface,
+        fetchSingleEventUseCase: FetchSingleEventUseCaseInterface,
+        refuseEventUseCase: RefuseEventUseCaseInterface
     ) {
         self.getNotesUseCase = getNotesUseCase
         self.setNoteLikeUseCase = setNoteLikeUseCase
@@ -52,6 +57,8 @@ final public class HomeViewModel {
         self.getHasUncheckedNotificationUseCase = getHasUncheckedNotificationUseCase
         self.blockUserUseCase = blockUserUseCase
         self.checkFirstVisitorUseCase = checkFirstVisitorUseCase
+        self.fetchSingleEventUseCase = fetchSingleEventUseCase
+        self.refuseEventUseCase = refuseEventUseCase
     }
     
     func fetchArtistsAndNotes(
@@ -330,7 +337,7 @@ extension HomeViewModel {
         .mapToResult()
         .sink { [weak self] result in
             switch result {
-            case .success(let success):
+            case .success:
                 self?.fetchedNotes.removeAll(where: { $0.publisher.id == id })
                 self?.blockUserResult = .success
                 
@@ -339,5 +346,47 @@ extension HomeViewModel {
             }
         }
         .store(in: &cancellables)
+    }
+}
+
+// MARK: - Event
+
+extension HomeViewModel {
+    func fetchFeelinEvent() {
+        self.fetchSingleEventUseCase.execute()
+            .mapToResult()
+            .sink { [weak self] result in
+                switch result {
+                case .success(let event):
+                    self?.feelinEvent = event
+                    
+                case .failure(let error):
+                    self?.error = .eventError(error)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    func refuseEvent(eventId: Int) {
+        if let feelinEvent = feelinEvent {
+            self.refuseEventUseCase.execute(eventID: feelinEvent.id)
+                .mapToResult()
+                .sink { [weak self] result in
+                    switch result {
+                    case .success(let didRefuse):
+                        if !didRefuse {
+                            self?.error = .eventError(.unknown(errorDescription: "이벤트 거부 실패."))
+                        }
+                        
+                        
+                    case .failure(let error):
+                        self?.error = .eventError(error)
+                    }
+                }
+                .store(in: &cancellables)
+            
+        } else {
+            self.error = .eventError(.unknown(errorDescription: "이벤트 id를 찾을 수 없습니다."))
+        }
     }
 }

--- a/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/BannerCell.swift
+++ b/Projects/Feature/Home/Interface/Sources/Views/Cells+SupplementaryViews/BannerCell.swift
@@ -16,8 +16,9 @@ final class BannerCell: UICollectionViewCell, Reusable {
     
     private var bannerImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = FeelinImages.feedbackBanner
         imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
         
         return imageView
     }()
@@ -42,8 +43,28 @@ final class BannerCell: UICollectionViewCell, Reusable {
     }
     
     private func setUpLayout() {
+        self.layer.cornerRadius = 8
         self.addSubview(flexContainer)
 
         flexContainer.flex.addItem(bannerImageView)
+    }
+    
+    public func configure(imageURL: URL) {
+        self.bannerImageView.kf.indicatorType = .activity
+        self.bannerImageView.kf.setImage(with: imageURL) { [weak self] result in
+            guard case .success = result else {
+                return
+            }
+            self?.bannerImageView.flex.markDirty()
+            
+            // 레이아웃 업데이트를 강제하여 최초 viewWillAppear 시점에도 이미지가 업데이트 될 수 있도록 하기 위해 호출
+            self?.flexContainer.flex.layout()
+        }
+    }
+    
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        bannerImageView.kf.cancelDownloadTask()
+        bannerImageView.image = nil
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Buttons/FeelinConfirmButton.swift
+++ b/Projects/Shared/DesignSystem/Sources/Buttons/FeelinConfirmButton.swift
@@ -39,7 +39,7 @@ public class FeelinConfirmButton: UIButton {
         super.init(coder: coder)
     }
 
-    private func setupButton(title: String) {
+    func setupButton(title: String) {
         updateAppearance()
 
         self.setTitle(title, for: .normal)

--- a/Projects/Shared/DesignSystem/Sources/Extensions/UIViewController+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extensions/UIViewController+.swift
@@ -125,7 +125,7 @@ extension UIViewController {
         return topMostViewController
     }
 
-    private var isFeelinAlertAlreadyPresented: Bool {
+    fileprivate var isFeelinAlertAlreadyPresented: Bool {
         return getTopMostViewController() is FeelinAlertViewController
     }
 }
@@ -189,5 +189,75 @@ public extension UIViewController {
             return presented.topMostPresented
         }
         return self
+    }
+}
+
+// MARK: - Event PopUp
+
+extension UIViewController {
+    fileprivate var isFeelinPopUpAlreadyPresented: Bool {
+        return getTopMostViewController() is FeelinAlertViewController
+    }
+    
+    private func showPopUp(
+        contentImageUrl: URL,
+        leftTopActionTitle: String?,
+        leftTopActionImage: UIImage?,
+        rightTopActionTitle: String?,
+        rightTopActionImage: UIImage?,
+        leftTopActionCompletion: (() -> Void)?,
+        rightTopActionCompletion: (() -> Void)?,
+        bottomActionTitle: String,
+        bottomActionCompletion: (() -> Void)?
+    ) {
+        let eventView = FeelinEventView()
+        eventView.loadImage(from: contentImageUrl)
+        eventView.setButton(
+            title: bottomActionTitle,
+            onTap: bottomActionCompletion
+        )
+        
+        let popUpViewController = FeelinPopUpViewController(popUpContentView: eventView)
+        
+        popUpViewController.setLeftTopButton(
+            title: leftTopActionTitle,
+            image: leftTopActionImage,
+            onTap: leftTopActionCompletion
+        )
+        
+        popUpViewController.setRightTopButton(
+            title: rightTopActionTitle,
+            image: rightTopActionImage,
+            onTap: rightTopActionCompletion
+        )
+        
+        guard !isFeelinAlertAlreadyPresented || !isFeelinPopUpAlreadyPresented else {
+            print("is feelin alert pres: \(isFeelinAlertAlreadyPresented), is feelin popup : \(isFeelinPopUpAlreadyPresented)")
+            return
+        }
+        
+        present(popUpViewController, animated: false)
+    }
+    
+    public func showEventPopUp(
+        contentImageUrl: URL,
+        leftTopActionTitle: String = "오늘 하루 보지 않기",
+        rightTopActionImage: UIImage = FeelinImages.x.withTintColor(.white),
+        leftTopActionCompletion: (() -> Void)?,
+        rightTopActionCompletion: (() -> Void)?,
+        bottomActionTitle: String,
+        bottomActionCompletion: (() -> Void)?
+    ) {
+        self.showPopUp(
+            contentImageUrl: contentImageUrl,
+            leftTopActionTitle: leftTopActionTitle,
+            leftTopActionImage: nil,
+            rightTopActionTitle: nil,
+            rightTopActionImage: rightTopActionImage,
+            leftTopActionCompletion: leftTopActionCompletion,
+            rightTopActionCompletion: rightTopActionCompletion,
+            bottomActionTitle: bottomActionTitle,
+            bottomActionCompletion: bottomActionCompletion
+        )
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/ViewControllers/FeelinPopUpViewController.swift
+++ b/Projects/Shared/DesignSystem/Sources/ViewControllers/FeelinPopUpViewController.swift
@@ -1,0 +1,138 @@
+//
+//  FeelinPopUpViewController.swift
+//  SharedDesignSystem
+//
+//  Created by 황인우 on 2/23/25.
+//
+
+import UIKit
+import SharedUtil
+
+public final class FeelinPopUpViewController: UIViewController {
+    
+    private var leftTopButton: UIButton = .init()
+    
+    private var rightTopButton: UIButton = .init()
+    
+    private var topButtonStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        
+        return view
+    }()
+    
+    private var totalStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private var popUpContentView: UIView
+    
+    public init(popUpContentView: UIView) {
+        self.popUpContentView = popUpContentView
+        self.popUpContentView.translatesAutoresizingMaskIntoConstraints = false
+        super.init(nibName: nil, bundle: nil)
+        
+        self.modalPresentationStyle = .overFullScreen
+        self.overrideUserInterfaceStyle = .light
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        self.setColor()
+        self.addViews()
+        self.activateConstraints()
+        
+    }
+    
+    public func setLeftTopButton(
+        title: String?,
+        image: UIImage?,
+        onTap: (() -> Void)?
+    ) {
+        if let title = title {
+            self.leftTopButton.setAttributedTitle(
+                title,
+                color: .white,
+                font: SharedDesignSystemFontFamily.Pretendard.semiBold.font(
+                    size: 14
+                ),
+                for: .normal
+            )
+        }
+        self.leftTopButton.setImage(image, for: .normal)
+        self.leftTopButton.addAction(
+            .init(handler: {
+                [weak self] _ in
+                self?.dismiss(
+                    animated: false,
+                    completion: onTap
+                )
+            }),
+            for: .touchUpInside
+        )
+    }
+    
+    public func setRightTopButton(
+        title: String?,
+        image: UIImage?,
+        onTap: (() -> Void)?
+    ) {
+        if let title = title {
+            self.rightTopButton.setAttributedTitle(
+                title,
+                color: .white,
+                font: SharedDesignSystemFontFamily.Pretendard.semiBold.font(
+                    size: 16
+                ),
+                for: .normal
+            )
+        }
+        
+        self.rightTopButton.setImage(image, for: .normal)
+        
+        self.rightTopButton.addAction(
+            .init(handler: {
+                [weak self] _ in
+                self?.dismiss(
+                    animated: false,
+                    completion: onTap
+                )
+            }),
+            for: .touchUpInside
+        )
+    }
+    
+    private func setColor() {
+        self.view.backgroundColor = Colors.dim
+    }
+    
+    private func addViews() {
+        let gapView = UIView()
+        gapView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        topButtonStackView.addArrangedSubview(leftTopButton)
+        topButtonStackView.addArrangedSubview(gapView)
+        topButtonStackView.addArrangedSubview(rightTopButton)
+        
+        totalStackView.addArrangedSubview(topButtonStackView)
+        totalStackView.addArrangedSubview(popUpContentView)
+        
+        self.view.addSubview(totalStackView)
+    }
+    
+    private func activateConstraints() {
+        NSLayoutConstraint.activate([
+            totalStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 30),
+            totalStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -30),
+            totalStackView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+        ])
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/Views/FeelinEventView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Views/FeelinEventView.swift
@@ -1,0 +1,158 @@
+//
+//  FeelinEventView.swift
+//  SharedDesignSystem
+//
+//  Created by 황인우 on 2/23/25.
+//
+
+import UIKit
+
+public final class FeelinEventView: UIView {
+    private let eventImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        
+        // 이미지뷰가 스택뷰를 벗어나서 커지지 않는 세팅
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 16
+        return imageView
+    }()
+    
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+    
+    private var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
+    }()
+    
+    private var feedbackButton: FeelinConfirmButton =  {
+        let button = FeelinConfirmButton(
+            initialEnabled: true,
+            title: ""
+        )
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentHuggingPriority(.defaultLow, for: .vertical)
+        button.layer.cornerRadius = 8
+        
+        return button
+    }()
+    
+    private var imageHeightConstraint: NSLayoutConstraint = .init()
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required public init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        // layoutSubviews에서 이미지 크기를 조정한다.
+        self.adjustImageHeight()
+    }
+    
+    private func setupView() {
+        self.backgroundColor = .white
+        self.layer.cornerRadius = 16
+        
+        self.addSubview(activityIndicator)
+        self.addSubview(feedbackButton)
+        self.stackView.addArrangedSubview(eventImageView)
+        self.addSubview(stackView)
+        
+        setupConstraints()
+    }
+    
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            // 인디케이터 위치
+            activityIndicator.centerXAnchor.constraint(equalTo: eventImageView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: eventImageView.centerYAnchor),
+            
+            stackView.topAnchor.constraint(equalTo: self.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: self.feedbackButton.topAnchor),
+            
+            feedbackButton.heightAnchor.constraint(equalToConstant: 55),
+            feedbackButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 24),
+            feedbackButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24),
+            feedbackButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -22)
+        ])
+    }
+    
+    public func loadImage(
+        from url: URL,
+        retryCount: Int = 3
+    ) {
+        DispatchQueue.main.async {
+            self.activityIndicator.startAnimating()
+        }
+
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            DispatchQueue.main.async {
+                if let image = self.processImageData(data, error: error) {
+                    self.eventImageView.image = image
+                    self.activityIndicator.stopAnimating()
+                } else if retryCount > 0 {
+                    self.retryLoadingImage(from: url, retryCount: retryCount - 1)
+                }
+            }
+        }.resume()
+    }
+
+    private func processImageData(_ data: Data?, error: Error?) -> UIImage? {
+        if let error = error {
+            return nil
+        }
+        guard let data = data, let image = UIImage(data: data) else {
+            return nil
+        }
+        return image
+    }
+
+    private func retryLoadingImage(from url: URL, retryCount: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.loadImage(from: url, retryCount: retryCount)
+        }
+    }
+    
+    private func adjustImageHeight() {
+        let imageViewWidth: CGFloat = self.frame.width
+        
+        let defaultAspectRatio: CGFloat = 1.25
+        
+        var calculatedHeight = imageViewWidth * defaultAspectRatio
+        
+        // 새로운 높이로 업데이트
+        imageHeightConstraint = eventImageView.heightAnchor.constraint(equalToConstant: calculatedHeight)
+        imageHeightConstraint.isActive = true
+    }
+    
+    public func setButton(
+        title: String,
+        onTap: (() -> Void)?
+    ) {
+        self.feedbackButton.setupButton(title: title)
+        self.feedbackButton.addAction(
+            .init(handler: {
+                _ in
+                onTap?()
+            }),
+            for: .touchUpInside
+        )
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/Views/FeelinEventView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Views/FeelinEventView.swift
@@ -53,9 +53,9 @@ public final class FeelinEventView: UIView {
         setupView()
     }
     
+    @available(*, unavailable)
     required public init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupView()
+        fatalError()
     }
     
     public override func layoutSubviews() {


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [ ] 버그 수정
- [x] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [ ] Other... 추가 설명 요망:


## 배경
- Feelin 이벤트 발생 시 관련 팝업을 유저에게 보여줄 수 있어야 하며 홈화면 상단 배너 또한 관련 이벤트에 맞게 변경되어야 합니다.

## 목표
- 이벤트 존재 시 홈화면에서 이벤트 팝업 출력 (로그인 & 비로그인 유저 모두 해당)
- 이벤트 존재 시 홈화면 상단 배너에서 관련 내용 출력 (로그인 & 비로그인 유저 모두 해당)
- 이밴트 거부 시 하루동안 팝업이 뜨지 않도록 설정

## 결과 (Optional)
- [x] 이벤트 팝업 출력 기능 구현
- [x] 이벤트 배너 적용

|이벤트 팝업(로그인)|이벤트 팝업(비로그인)|
|--|--|
|<img src="https://github.com/user-attachments/assets/42c47cc3-6628-4dc1-88a1-296dc4de6208" width="250">|<img src="https://github.com/user-attachments/assets/191336e0-8cdf-4902-8597-c3f35196e8ac" width="250">|
