### PR TITLE
Chore: Pulse 라이브러리를 이용한 네트워크 로깅 개선

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Configuration.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Configuration.swift
@@ -16,7 +16,7 @@ extension Configuration {
             return .debug(
                 name: type.configurationName,
                 settings: [
-                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
+                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING \(type.rawValue)",
                     "ENABLE_TESTABILITY": true
                 ],
                 xcconfig: .relativeToXCConfig(target: .dev)
@@ -25,7 +25,7 @@ extension Configuration {
             return .debug(
                 name: type.configurationName,
                 settings: [
-                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
+                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING \(type.rawValue)",
                     "ENABLE_TESTABILITY": true
                 ],
                 xcconfig: .relativeToXCConfig(target: .qa)
@@ -34,6 +34,7 @@ extension Configuration {
             return .release(
                 name: type.configurationName,
                 settings: [
+                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING \(type.rawValue)",
                     "ENABLE_TESTABILITY": true
                 ],
                 xcconfig: .relativeToXCConfig(target: .prod)

--- a/Projects/App/Sources/Application/DebuggerWindow.swift
+++ b/Projects/App/Sources/Application/DebuggerWindow.swift
@@ -115,7 +115,7 @@ public final class DebuggerWindow: UIWindow {
             .store(in: &cancellables)
     }
     
-    private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+    private func handlePanGesture(_ gesture: UIGestureRecognizer) {
         switch gesture.state {
         case .began:
             isMoving = true

--- a/Projects/App/Sources/Application/DebuggerWindow.swift
+++ b/Projects/App/Sources/Application/DebuggerWindow.swift
@@ -1,0 +1,235 @@
+//
+//  DebuggerWindow.swift
+//  Feelin
+//
+//  Created by 황인우 on 9/5/25.
+//
+
+//  DebuggerWindow.swift
+//  Feelin
+//
+//  Created for Pulse Console Integration
+
+import UIKit
+import Combine
+import SwiftUI
+import Shared
+import PulseUI
+
+public final class DebuggerWindow: UIWindow {
+    private enum Metric {
+        static let padding: CGFloat = 12.0
+        static let buttonSize: CGFloat = 50.0
+    }
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    private lazy var toggleButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        config.image = UIImage(systemName: "wrench.and.screwdriver.fill")
+        config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        config.baseBackgroundColor = .black
+        config.baseForegroundColor = .white
+        config.cornerStyle = .capsule
+        
+        let button = UIButton(configuration: config)
+        button.alpha = 0.3
+        
+        return button
+    }()
+    
+    private let _rootViewController: UIViewController = InvisibleViewController()
+    
+    private let navigationController: UINavigationController
+    
+    private var isMoving = false {
+        didSet {
+            updateToggleButtonAlpha()
+        }
+    }
+    
+    private var isSlightlyVisible: Bool = true {
+        didSet {
+            
+        }
+    }
+    
+    private var dragOffset: CGPoint = .zero
+    
+    override public init(windowScene: UIWindowScene) {
+        
+        UserDefaults.standard.set(true, forKey: "pulse-disable-support-prompts")
+        UserDefaults.standard.set(true, forKey: "pulse-disable-report-issue-prompts")
+        
+        navigationController = UINavigationController(rootViewController: _rootViewController)
+        navigationController.navigationBar.tintColor = .black
+        
+        super.init(windowScene: windowScene)
+        
+        self.rootViewController = navigationController
+        backgroundColor = .clear
+        
+        setupUI()
+        setupGestures()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        addSubview(toggleButton)
+        
+        toggleButton.bounds = CGRect(
+            x: 0,
+            y: 0,
+            width: Metric.buttonSize,
+            height: Metric.buttonSize
+        )
+        
+        let centerX = bounds.width - safeAreaInsets.right - Metric.padding - Metric.buttonSize / 2
+        let centerY = safeAreaInsets.top + Metric.padding + Metric.buttonSize / 2
+        
+        toggleButton.center = CGPoint(x: centerX, y: centerY)
+    }
+    
+    private func setupGestures() {
+        let panGesture = UIPanGestureRecognizer()
+        toggleButton.addGestureRecognizer(panGesture)
+        
+        panGesture.publisher
+            .sink { [weak self] gesture in
+                self?.handlePanGesture(gesture)
+            }
+            .store(in: &cancellables)
+        
+        let tapGesture = UITapGestureRecognizer()
+        toggleButton.addGestureRecognizer(tapGesture)
+        
+        tapGesture.publisher
+            .sink { [weak self] _ in
+                self?.showPulseConsole()
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            isMoving = true
+            
+            let gestureLocation = gesture.location(in: self)
+            let buttonCenter = toggleButton.center
+            dragOffset = CGPoint(
+                x: buttonCenter.x - gestureLocation.x,
+                y: buttonCenter.y - gestureLocation.y
+            )
+            
+        case .changed:
+            let location = gesture.location(in: self)
+            updatePosition(location: location)
+            
+        case .ended, .cancelled, .failed:
+            handlePanGestureEnded()
+            
+        default:
+            break
+        }
+    }
+    
+    private func updatePosition(location: CGPoint) {
+        var centerX = location.x + dragOffset.x
+        var centerY = location.y + dragOffset.y
+        
+        let buttonHalfWidth = toggleButton.bounds.width / 2
+        let buttonHalfHeight = toggleButton.bounds.height / 2
+        
+        let minX = safeAreaInsets.left + Metric.padding + buttonHalfWidth
+        let maxX = bounds.width - safeAreaInsets.right - Metric.padding - buttonHalfWidth
+        let minY = safeAreaInsets.top + Metric.padding + buttonHalfHeight
+        let maxY = bounds.height - safeAreaInsets.bottom - Metric.padding - buttonHalfHeight
+        
+        centerX = min(maxX, max(minX, centerX))
+        centerY = min(maxY, max(minY, centerY))
+        
+        toggleButton.center = CGPoint(x: centerX, y: centerY)
+    }
+    
+    private func handlePanGestureEnded() {
+        let isLeftSide = toggleButton.center.x < (bounds.width / 2)
+        
+        let buttonHalfWidth = toggleButton.bounds.width / 2
+        let targetX: CGFloat
+        
+        if isLeftSide {
+            // 왼쪽 가장자리로 스냅
+            targetX = safeAreaInsets.left + Metric.padding + buttonHalfWidth
+        } else {
+            // 오른쪽 가장자리로 스냅
+            targetX = bounds.width - safeAreaInsets.right - Metric.padding - buttonHalfWidth
+        }
+        
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            usingSpringWithDamping: 0.8,
+            initialSpringVelocity: 0
+        ) {
+            self.toggleButton.center.x = targetX
+            // y 좌표는 현재 위치 유지
+        } completion: { _ in
+            self.isMoving = false
+        }
+    }
+    
+    private func updateToggleButtonAlpha() {
+        let alpha: CGFloat = isMoving ? 0.8 : 0.3
+        UIView.animate(withDuration: 0.2) {
+            self.toggleButton.alpha = alpha
+        }
+    }
+    
+    private func showPulseConsole() {
+        let consoleView = NavigationView {
+            ConsoleView()
+        }
+        
+        let hostingController = UIHostingController(rootView: consoleView)
+        hostingController.modalPresentationStyle = .fullScreen
+        
+        navigationController.present(hostingController, animated: true)
+    }
+    
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        // 오직 toggleButton만 터치 가능하도록 제한
+        guard navigationController.viewControllers.count == 1 &&
+              navigationController.presentedViewController == nil else {
+            return super.hitTest(point, with: event)
+        }
+        
+        if let view = hitTest(on: toggleButton, point: point, with: event) {
+            return view
+        }
+        return nil
+    }
+    
+    private func hitTest(on view: UIView, point: CGPoint, with event: UIEvent?) -> UIView? {
+        view.hitTest(view.convert(point, from: self), with: event)
+    }
+}
+
+// MARK: - InvisibleViewController
+
+final class InvisibleViewController: UIViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+}

--- a/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/Projects/App/Sources/Application/SceneDelegate.swift
@@ -7,10 +7,13 @@
 
 import CoordinatorAppInterface
 import KakaoSDKAuth
+
+import SwiftUI
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    var debuggerWindow: UIWindow?
     var coordinator: Coordinator?
 
     func scene(
@@ -29,6 +32,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
+        
+        #if DEV || QA
+        debuggerWindow = DebuggerWindow(windowScene: windowScene)
+        debuggerWindow?.windowLevel = .alert
+        debuggerWindow?.makeKeyAndVisible()
+        #endif
 
         coordinator?.start()
     }

--- a/Projects/Core/Network/Interface/Sources/NetworkSession.swift
+++ b/Projects/Core/Network/Interface/Sources/NetworkSession.swift
@@ -8,17 +8,23 @@
 import Combine
 import Foundation
 
+import Pulse
+
 public typealias DataTaskResult = (data: Data, response: URLResponse)
 
 open class NetworkSession {
-    public let urlSession: URLSession
+    public let urlSession: URLSessionProtocol
     public var requestInterceptor: URLRequestInterceptor?
     
     public init(
-        urlSession: URLSession = .shared,
+        urlSession: URLSession = URLSession(configuration: .default),
         requestInterceptor: URLRequestInterceptor?
     ) {
+        #if PROD
         self.urlSession = urlSession
+        #else
+        self.urlSession = URLSessionProxy(configuration: .default)
+        #endif
         self.requestInterceptor = requestInterceptor
     }
     
@@ -26,16 +32,46 @@ open class NetworkSession {
         if let interceptor = requestInterceptor {
             return interceptor.adapt(request)
                 .flatMap { [unowned self] adaptedRequest -> AnyPublisher<DataTaskResult, Error> in
-                    return urlSession.dataTaskPublisher(for: adaptedRequest)
+                    return self._dataTaskPublisher(for: adaptedRequest)
                         .mapError { $0 as Error }
                         .eraseToAnyPublisher()
                 }
                 .eraseToAnyPublisher()
             
         } else {
-            return urlSession.dataTaskPublisher(for: request)
+            return self._dataTaskPublisher(for: request)
                 .mapError { $0 as Error }
                 .eraseToAnyPublisher()
         }
+    }
+}
+
+// Pulse에서 제공하는 dataTaskPublisher를 사용할 경우 response 로그가 기록되지 않는 문제가 있음
+// 반면, 다른 dataTask 메서드는 정상적으로 로그가 기록되므로
+// 추후 이 부분이 해결되기 전까지 임시 방편으로 URLSessionProtocol의 dataTask를 Publisher로 감싸서 사용하여 문제를 해결.
+private extension NetworkSession {
+    func _dataTaskPublisher(for url: URL) -> AnyPublisher<URLSession.DataTaskPublisher.Output, URLSession.DataTaskPublisher.Failure> {
+        _dataTaskPublisher(for: URLRequest(url: url))
+    }
+
+    func _dataTaskPublisher(for request: URLRequest) -> AnyPublisher<URLSession.DataTaskPublisher.Output, URLSession.DataTaskPublisher.Failure> {
+        Future { [weak self] promise in
+            guard let self else {
+                promise(.failure(URLError(.unknown)))
+                return
+            }
+            
+            let task = self.urlSession.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    promise(.failure(error as? URLError ?? URLError(.unknown)))
+                } else if let data = data, let response = response {
+                    promise(.success((data: data, response: response)))
+                } else {
+                    promise(.failure(URLError(.badServerResponse)))
+                }
+            }
+            task.resume()
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/Projects/Core/Network/Interface/Sources/URLRequestInterceptor.swift
+++ b/Projects/Core/Network/Interface/Sources/URLRequestInterceptor.swift
@@ -8,6 +8,8 @@
 import Combine
 import Foundation
 
+import Pulse
+
 public enum RetryResult {
     case retry
     case doNotRetry
@@ -17,7 +19,7 @@ public enum RetryResult {
 public protocol URLRequestInterceptor: AnyObject {
     func adapt(_ urlRequest: URLRequest) -> AnyPublisher<URLRequest, Error>
     func retry(
-        with session: URLSession,
+        with session: URLSessionProtocol,
         dueTo error: NetworkError
     ) -> AnyPublisher<RetryResult, Never>
 }

--- a/Projects/Core/Network/Sources/TokenInterceptor.swift
+++ b/Projects/Core/Network/Sources/TokenInterceptor.swift
@@ -9,6 +9,7 @@ import Combine
 import CoreLocalStorageInterface
 import CoreNetworkInterface
 import Shared
+import Pulse
 
 import Foundation
 
@@ -48,7 +49,7 @@ extension TokenInterceptor: URLRequestInterceptor {
     }
     
     public func retry(
-        with session: URLSession,
+        with session: URLSessionProtocol,
         dueTo error: NetworkError
     ) -> AnyPublisher<RetryResult, Never> {
         guard case let .feelinAPIError(feelinAPIError) = error,
@@ -97,7 +98,7 @@ extension TokenInterceptor: URLRequestInterceptor {
     
     private func reissueToken(
         request: URLRequest,
-        with session: URLSession
+        with session: URLSessionProtocol
     ) -> AnyPublisher<RetryResult, Never> {
         return session
             .dataTaskPublisher(for: request)

--- a/Projects/DependencyInjection/Sources/DIContainer/DIContainer.swift
+++ b/Projects/DependencyInjection/Sources/DIContainer/DIContainer.swift
@@ -31,10 +31,7 @@ public extension DIContainer {
                 requestInterceptor = TokenInterceptor(tokenStorage: tokenStorage)
             }
 
-            let networkSession = NetworkSession(
-                urlSession: URLSession.shared,
-                requestInterceptor: requestInterceptor
-            )
+            let networkSession = NetworkSession(requestInterceptor: requestInterceptor)
             return NetworkProvider(networkSession: networkSession)
         }
     }
@@ -109,10 +106,7 @@ public extension DIContainer {
     
     static func registerDependenciesForHomeView() {
         standard.register(.networkProvider) { _ in
-            let networkSession = NetworkSession(
-                urlSession: .shared,
-                requestInterceptor: TokenInterceptor(tokenStorage: TokenStorage())
-            )
+            let networkSession = NetworkSession(requestInterceptor: TokenInterceptor(tokenStorage: TokenStorage()))
             
             return NetworkProvider(networkSession: networkSession)
         }

--- a/Projects/Shared/ThirdPartyLib/Project.swift
+++ b/Projects/Shared/ThirdPartyLib/Project.swift
@@ -26,7 +26,9 @@ let targets: [Target] = [
                 .SPM.KakaoSDKAuth,
                 .SPM.KakaoSDKUser,
                 .SPM.KakaoSDKCommon,
-                .Carthage.FlexLayout
+                .SPM.Pulse,
+                .SPM.PulseUI,
+                .Carthage.FlexLayout,
             ]
         )
     )
@@ -37,7 +39,8 @@ let project: Project = .makeModule(
 	packages: [
 		.remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
 		.remote(url: "https://github.com/layoutBox/PinLayout", requirement: .upToNextMajor(from: "1.10.5")),
-		.remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.22.1"))
+		.remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.22.1")),
+        .remote(url: "https://github.com/kean/Pulse", requirement: .upToNextMajor(from: "5.1.4"))
 	],
     targets: targets
 )

--- a/Projects/Shared/Util/Sources/Extensions/Combine/UIGestureRecognizer+Combine.swift
+++ b/Projects/Shared/Util/Sources/Extensions/Combine/UIGestureRecognizer+Combine.swift
@@ -9,41 +9,72 @@ import Combine
 import UIKit
 
 public extension UITapGestureRecognizer {
-    // UITapGestureRecognizer를 Combine 퍼블리셔로 확장
     var publisher: AnyPublisher<UITapGestureRecognizer, Never> {
         GesturePublisher(gesture: self).eraseToAnyPublisher()
     }
 }
 
-struct GesturePublisher: Publisher {
-    typealias Output = UITapGestureRecognizer
-    typealias Failure = Never
+public extension UIPanGestureRecognizer {
+    var publisher: AnyPublisher<UIPanGestureRecognizer, Never> {
+        GesturePublisher(gesture: self).eraseToAnyPublisher()
+    }
+}
 
-    let gesture: UITapGestureRecognizer
+public extension UILongPressGestureRecognizer {
+    var publisher: AnyPublisher<UILongPressGestureRecognizer, Never> {
+        GesturePublisher(gesture: self).eraseToAnyPublisher()
+    }
+}
 
-    func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
-        let subscription = GestureSubscription(subscriber: subscriber, gesture: gesture)
+public extension UIPinchGestureRecognizer {
+    var publisher: AnyPublisher<UIPinchGestureRecognizer, Never> {
+        GesturePublisher(gesture: self).eraseToAnyPublisher()
+    }
+}
+
+public extension UISwipeGestureRecognizer {
+    var publisher: AnyPublisher<UISwipeGestureRecognizer, Never> {
+        GesturePublisher(gesture: self).eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Gesture Publisher
+
+public struct GesturePublisher<Gesture: UIGestureRecognizer>: Publisher {
+    public typealias Output = Gesture
+    public typealias Failure = Never
+
+    let gesture: Gesture
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+        let subscription = GestureSubscription(
+            subscriber: subscriber,
+            gesture: gesture
+        )
         subscriber.receive(subscription: subscription)
     }
 }
 
-final class GestureSubscription<S: Subscriber>: Subscription where S.Input == UITapGestureRecognizer {
+public final class GestureSubscription<S: Subscriber, Gesture: UIGestureRecognizer>: Subscription
+where S.Input == Gesture, S.Failure == Never {
     private var subscriber: S?
-    private weak var gesture: UITapGestureRecognizer?
+    private weak var gesture: Gesture?
 
-    init(subscriber: S, gesture: UITapGestureRecognizer) {
+    init(subscriber: S, gesture: Gesture) {
         self.subscriber = subscriber
         self.gesture = gesture
         gesture.addTarget(self, action: #selector(handleGesture))
     }
 
-    func request(_ demand: Subscribers.Demand) { }
+    public func request(_ demand: Subscribers.Demand) { }
 
-    func cancel() {
+    public func cancel() {
         subscriber = nil
+        gesture?.removeTarget(self, action: #selector(handleGesture))
     }
 
     @objc private func handleGesture() {
-        _ = subscriber?.receive(gesture!)
+        guard let gesture = gesture else { return }
+        _ = subscriber?.receive(gesture)
     }
 }

--- a/Projects/Shared/Util/Sources/Extensions/Combine/UIGestureRecognizer+Combine.swift
+++ b/Projects/Shared/Util/Sources/Extensions/Combine/UIGestureRecognizer+Combine.swift
@@ -8,32 +8,8 @@
 import Combine
 import UIKit
 
-public extension UITapGestureRecognizer {
-    var publisher: AnyPublisher<UITapGestureRecognizer, Never> {
-        GesturePublisher(gesture: self).eraseToAnyPublisher()
-    }
-}
-
-public extension UIPanGestureRecognizer {
-    var publisher: AnyPublisher<UIPanGestureRecognizer, Never> {
-        GesturePublisher(gesture: self).eraseToAnyPublisher()
-    }
-}
-
-public extension UILongPressGestureRecognizer {
-    var publisher: AnyPublisher<UILongPressGestureRecognizer, Never> {
-        GesturePublisher(gesture: self).eraseToAnyPublisher()
-    }
-}
-
-public extension UIPinchGestureRecognizer {
-    var publisher: AnyPublisher<UIPinchGestureRecognizer, Never> {
-        GesturePublisher(gesture: self).eraseToAnyPublisher()
-    }
-}
-
-public extension UISwipeGestureRecognizer {
-    var publisher: AnyPublisher<UISwipeGestureRecognizer, Never> {
+public extension UIGestureRecognizer {
+    var publisher: AnyPublisher<UIGestureRecognizer, Never> {
         GesturePublisher(gesture: self).eraseToAnyPublisher()
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/SPM.swift
@@ -18,6 +18,8 @@ public extension TargetDependency.SPM {
     static let KakaoSDKCommon = Self.package(product: "KakaoSDKCommon")
     static let KakaoSDKAuth = Self.package(product: "KakaoSDKAuth")
     static let KakaoSDKUser = Self.package(product: "KakaoSDKUser")
+    static let Pulse = Self.package(product: "Pulse")
+    static let PulseUI = Self.package(product: "PulseUI")
 
     private static func external(_ name: String) -> TargetDependency {
         return TargetDependency.external(name: name)


### PR DESCRIPTION
## PR 타입
어떤 변경에 대한 PR인가요?

<!-- 아래 체크리스트 중 해당 되는 부분에 체크해주세요 "x". -->

- [ ] 버그 수정
- [ ] Feature / 신기능
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련된 변경사항
- [ ] Documentation content changes
- [ ] 구조 변경
- [x] Other... 추가 설명 요망: 네트워크 디버깅 환경 개선


## 배경
- 개발 중 네트워크 로그를 확인 해야할 경우가 빈번한데 lldb를 활용하는 경우 가독성이 떨어지는 문제가 있습니다. 또한 QA 및 백앤드 팀에서는 LLDB 로그를 직접 확인하는 것이 불가능하니 문제를 빠르게 대응할 수 없습니다.

- 이런 문제를 개선하기 위해 QA | DEV 환경에서 네트워크 로그를 더 수월하게 확인할 수 있는 기능이 필요합니다.

추후 다른 주요 로그들 또한 해당 ConsolView를 활용해서 볼 수 있도록 해도 괜찮을 듯 합니다.

@gdaegeun539 , @hyunjung-choi 잘 아시고 이미 활용하고 계실 것도 같지만 안드로이드에도 비슷한 기능이 있으면 개발하실 때 도움이 될듯 하여 살포시 태그 해 봅니다 :)

## 목표
- [x] Pulse Library 도입
- [x] ConsolView를 빠르고 쉽게 확인할 수 있는 기능 추가

## 결과 (Optional)
- DEV, QA 환경에서는 콘솔 버튼이 보인다
- PROD 환경에서는 콘솔 버튼이 보이지 않는다.

| Pulse applied PROD | Pulse applied DEV |
|--|--|
| <img src="https://github.com/user-attachments/assets/03206b4e-1599-4ecd-a62d-0ad50a2435de" width="250"> | <img src="https://github.com/user-attachments/assets/5ca7b39a-b78c-44ce-9aa0-820a0e644f21" width="250"> |


## Trouble or Trouble Shooting(Optional)
Pulse에서 제공하는 URLSessionProtocol의 dataTaskPublisher를 사용할 경우 response 로그가 기록되지 않는 문제가 있습니다.
반면, URLSessionProtocol의 다른 dataTask 메서드는 정상적으로 로그가 기록되므로
이를 다음과 같은 방법으로 해결하였습니다:

``` swift
private extension NetworkSession {
    func _dataTaskPublisher(for url: URL) -> AnyPublisher<URLSession.DataTaskPublisher.Output, URLSession.DataTaskPublisher.Failure> {
        _dataTaskPublisher(for: URLRequest(url: url))
    }

    func _dataTaskPublisher(for request: URLRequest) -> AnyPublisher<URLSession.DataTaskPublisher.Output, URLSession.DataTaskPublisher.Failure> {
        Future { [weak self] promise in
            guard let self else {
                promise(.failure(URLError(.unknown)))
                return
            }
            
            let task = self.urlSession.dataTask(with: request) { data, response, error in
                if let error = error {
                    promise(.failure(error as? URLError ?? URLError(.unknown)))
                } else if let data = data, let response = response {
                    promise(.success((data: data, response: response)))
                } else {
                    promise(.failure(URLError(.badServerResponse)))
                }
            }
            task.resume()
        }
        .eraseToAnyPublisher()
    }
}
```
